### PR TITLE
ci: install local vsjetpack before docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -r requirements-doc.txt
+          uv pip install -r requirements-doc.txt -e .
 
       - name: Restore build cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
The build was previously getting the published version via e.g. vsadjust and I didn't notice, oops.