### PR TITLE
insert_clip: combine repeated clip splicing

### DIFF
--- a/vstools/functions/utils.py
+++ b/vstools/functions/utils.py
@@ -481,7 +481,7 @@ def insert_clip(clip: vs.VideoNode, /, insert: vs.VideoNode, start_frame: int, s
         return pre + insert
 
     if insert_diff < 0:
-        return pre + insert + clip[insert_diff:]
+        return vs.core.std.Splice([pre, insert, clip[insert_diff:]])
 
     if strict:
         raise ClipLengthError(


### PR DESCRIPTION
A minor thing I noticed while reading the file.

Technically, it looks like current insert_clip works at runtime for `AudioNode`s as well as `VideoNode`s, and this change breaks it. But the type hints already require `VideoNode`s.