### PR TITLE
vskernels: support force params in zimg kernels

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -25,3 +25,23 @@ def test_blur(kernel: type[ZimgComplexKernel]) -> None:
 
         mock_descale_function.assert_called_once()
         assert mock_descale_function.call_args.kwargs["blur"] == 1.15
+
+@pytest.mark.parametrize("kernel", kernels)
+def test_force(kernel: type[ZimgComplexKernel]) -> None:
+    with patch.object(kernel, 'scale_function') as mock_scale_function:
+        kernel.scale(clip, 1600, 900, force=True)
+
+        mock_scale_function.assert_called_once()
+        assert mock_scale_function.call_args.kwargs["force"]
+
+    with patch.object(kernel, 'scale_function') as mock_scale_function:
+        kernel.scale(clip, 1600, 900, force_h=True)
+
+        mock_scale_function.assert_called_once()
+        assert mock_scale_function.call_args.kwargs["force_h"]
+
+    with patch.object(kernel, 'scale_function') as mock_scale_function:
+        kernel.scale(clip, 1600, 900, force_w=True)
+
+        mock_scale_function.assert_called_once()
+        assert mock_scale_function.call_args.kwargs["force_w"]

--- a/vskernels/kernels/zimg.py
+++ b/vskernels/kernels/zimg.py
@@ -59,7 +59,7 @@ class ZimgComplexKernel(ComplexKernel, ZimgDescaler):  # type: ignore[misc]
         args = super().get_params_args(is_descale, clip, width, height, **kwargs)
 
         if not is_descale:
-            for key in ('border_handling', 'ignore_mask', 'force', 'force_h', 'force_v'):
+            for key in ('border_handling', 'ignore_mask'):
                 args.pop(key, None)
 
         return args


### PR DESCRIPTION
resize2 supports all of `force`, `force_h`, and `force_w`, so they no longer need to be popped from the args.