### PR TITLE
clip_async_render: Add example and support SPathLike input

### DIFF
--- a/vstools/functions/render.py
+++ b/vstools/functions/render.py
@@ -59,12 +59,22 @@ def clip_async_render(
     backlog: int = -1, y4m: bool | None = None, async_requests: int | bool | AsyncRenderConf = False
 ) -> list[T] | None:
     """
-    Iterate over an entire clip and optionally write results in a file.
+    Iterate over an entire clip and optionally write results to a file.
 
-    This is mostly useful for metric gathering that must be performed before you do anything else.
+    This is mostly useful for metric gathering that must be performed before any other processing.
     This could be for example gathering scenechanges, per-frame heuristics, etc.
 
     It's highly recommended to perform as little filtering as possible on the input clip for speed purposes.
+
+    Example usage:
+
+    .. code-block:: python
+
+        # Gather scenechanges.
+        >>> scenechanges = clip_async_render(clip, None, 'Searching for scenechanges...', lambda n, f: get_prop(f, "_SceneChange", int))
+
+        # Gather average planes stats.
+        >>> avg_planes = clip_async_render(clip, None, 'Calculating average planes...', lambda n, f: get_prop(f, "PlaneStatsAverage", float))
 
     :param clip:            Clip to render.
     :param outfile:         Optional binary output to write.

--- a/vstools/functions/render.py
+++ b/vstools/functions/render.py
@@ -5,11 +5,16 @@ import operator
 from collections import deque
 from dataclasses import dataclass
 from math import floor
+from os import PathLike
+from pathlib import Path
 from typing import Any, BinaryIO, Callable, Literal, overload
 
 import vapoursynth as vs
 
-from jetpytools import CustomRuntimeError, CustomValueError, Sentinel, SentinelT, T, normalize_list_to_ranges
+from jetpytools import (
+    CustomRuntimeError, CustomValueError, Sentinel, SentinelT, SPath, SPathLike, T,
+    normalize_list_to_ranges
+)
 
 from ..exceptions import InvalidColorFamilyError
 from .progress import get_render_progress
@@ -38,7 +43,8 @@ class AsyncRenderConf:
 @overload
 def clip_async_render(
     clip: vs.VideoNode, outfile: BinaryIO | SPathLike | None = None, progress: str | Callable[[int, int], None] | None = None,
-    callback: None = None, prefetch: int = 0, backlog: int = -1, y4m: bool = False,
+    callback: None = None,
+    prefetch: int = 0, backlog: int = -1, y4m: bool | None = None,
     async_requests: int | bool | AsyncRenderConf = False
 ) -> None:
     ...
@@ -47,16 +53,28 @@ def clip_async_render(
 @overload
 def clip_async_render(
     clip: vs.VideoNode, outfile: BinaryIO | SPathLike | None = None, progress: str | Callable[[int, int], None] | None = None,
-    callback: Callable[[int, vs.VideoFrame], T] = ..., prefetch: int = 0,
-    backlog: int = -1, y4m: bool = False, async_requests: int | bool | AsyncRenderConf = False
+    callback: Callable[[int, vs.VideoFrame], T] = ...,
+    prefetch: int = 0, backlog: int = -1, y4m: bool | None = None,
+    async_requests: int | bool | AsyncRenderConf = False
 ) -> list[T]:
+    ...
+
+
+@overload
+def clip_async_render(
+    clip: vs.VideoNode, outfile: BinaryIO | SPathLike | None = None, progress: str | Callable[[int, int], None] | None = None,
+    callback: Callable[[int, vs.VideoFrame], T] | None = ...,
+    prefetch: int = 0, backlog: int = -1, y4m: bool | None = None,
+    async_requests: int | bool | AsyncRenderConf = False
+) -> list[T] | None:
     ...
 
 
 def clip_async_render(
     clip: vs.VideoNode, outfile: BinaryIO | SPathLike | None = None, progress: str | Callable[[int, int], None] | None = None,
-    callback: Callable[[int, vs.VideoFrame], T] | None = None, prefetch: int = 0,
-    backlog: int = -1, y4m: bool | None = None, async_requests: int | bool | AsyncRenderConf = False
+    callback: Callable[[int, vs.VideoFrame], T] | None = None,
+    prefetch: int = 0, backlog: int = -1, y4m: bool | None = None,
+    async_requests: int | bool | AsyncRenderConf = False
 ) -> list[T] | None:
     """
     Iterate over an entire clip and optionally write results to a file.
@@ -95,7 +113,7 @@ def clip_async_render(
 
     from .funcs import fallback
 
-    if isinstance(outfile, SPathLike):
+    if isinstance(outfile, (str, PathLike, Path, SPath)) and outfile is not None:
         with open(outfile, 'wb') as f:
             return clip_async_render(clip, f, progress, callback, prefetch, backlog, y4m, async_requests)
 


### PR DESCRIPTION
This PR does the following:

- Add an example usage to the docstrings (also very minor other docstring improvements)
- Add support for an SPathLike input. This should allow users to just pass a path and have it write to that rather than require them to pass a BinaryIO.