### PR TITLE
CI: Add explicit failure webhook message to all workflows

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: qoomon/actions--context@v2
+        id: context
+      - uses: tj-actions/branch-names@v8
+        id: branch-names
+
       - name: Get version number
         run: |
           echo "CURR_VER=v$(python -c "import runpy;runpy.run_path('_metadata.py', None, '__github__')")" >> $GITHUB_ENV
@@ -39,3 +44,13 @@ jobs:
       - name: Fallback
         if: steps.tagcheck.outputs.exists == 'true'
         run: echo "Nothing to see here, move along citizen"
+
+      - name: Post webhook for failure
+        if: failure()
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          embed-url: ${{ steps.context.outputs.job_log_url }}
+          embed-title: "[${{ github.event.repository.name }}] ${{ steps.context.outputs.job }} failed on ${{ steps.branch-names.outputs.current_branch }}"
+          username: "GitHub - ${{ github.repository }}"
+          avatar-url: https://github.githubassets.com/favicons/favicon.png

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,12 @@ jobs:
     env:
       PROD: true
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - uses: qoomon/actions--context@v2
+        id: context
+      - uses: tj-actions/branch-names@v8
+        id: branch-names
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,6 +66,16 @@ jobs:
         with:
           key: mkdocs-material-${{ hashfiles('.cache/**') }}
           path: .cache
+
+      - name: Post webhook for failure
+        if: failure()
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          embed-url: ${{ steps.context.outputs.job_log_url }}
+          embed-title: "[${{ github.event.repository.name }}] ${{ steps.context.outputs.job }} failed on ${{ steps.branch-names.outputs.current_branch }}"
+          username: "GitHub - ${{ github.repository }}"
+          avatar-url: https://github.githubassets.com/favicons/favicon.png
 
   docs-deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: qoomon/actions--context@v2
+        id: context
+      - uses: tj-actions/branch-names@v8
+        id: branch-names
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -46,3 +51,13 @@ jobs:
 
       - name: Running mypy on vstools
         run: uv run mypy vstools
+
+      - name: Post webhook for failure
+        if: failure()
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          embed-url: ${{ steps.context.outputs.job_log_url }}
+          embed-title: "[${{ github.event.repository.name }}] ${{ steps.context.outputs.job }} failed on ${{ steps.branch-names.outputs.current_branch }}"
+          username: "GitHub - ${{ github.repository }}"
+          avatar-url: https://github.githubassets.com/favicons/favicon.png

--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -16,6 +16,11 @@ jobs:
         steps:
         - uses: actions/checkout@v4
 
+        - uses: qoomon/actions--context@v2
+          id: context
+        - uses: tj-actions/branch-names@v8
+          id: branch-names
+
         - name: Prep Python
           uses: actions/setup-python@v2
           with:
@@ -44,3 +49,13 @@ jobs:
           run: exit 1
         - name: Publish to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
+
+        - name: Post webhook for failure
+          if: failure()
+          uses: tsickert/discord-webhook@v6.0.0
+          with:
+            webhook-url: ${{ secrets.WEBHOOK_URL }}
+            embed-url: ${{ steps.context.outputs.job_log_url }}
+            embed-title: "[${{ github.event.repository.name }}] ${{ steps.context.outputs.job }} failed on ${{ steps.branch-names.outputs.current_branch }}"
+            username: "GitHub - ${{ github.repository }}"
+            avatar-url: https://github.githubassets.com/favicons/favicon.png

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: qoomon/actions--context@v2
+        id: context
+      - uses: tj-actions/branch-names@v8
+        id: branch-names
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -59,3 +64,13 @@ jobs:
         with:
           file: coverage.xml
           format: cobertura
+
+      - name: Post webhook for failure
+        if: failure()
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          embed-url: ${{ steps.context.outputs.job_log_url }}
+          embed-title: "[${{ github.event.repository.name }}] ${{ steps.context.outputs.job }} failed on ${{ steps.branch-names.outputs.current_branch }}"
+          username: "GitHub - ${{ github.repository }}"
+          avatar-url: https://github.githubassets.com/favicons/favicon.png


### PR DESCRIPTION
Note that this won't magically work, needs a `WEBHOOK_URL` variable in repository secrets over [here](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jetpack/settings/secrets/actions).
