### PR TITLE
docs: include `_dpir`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,12 @@ plugins:
             filters:
               - "!^_"
               - "^__call__$"
+              - "^_dpir$"         # vs-denoise: mostly public via alias.
               - "^_dre_edgemask$" # vs-masktools: mostly public via alias.
+              - "^_fine_dehalo$"  # vs-dehalo: mostly public via alias.
+              - "^_get_prop$"     # vs-tools: mostly public via alias.
+              - "^_padder$"       # vs-tools: mostly public via alias.
+              - "^_pre_aa$"       # vs-aa: mostly public via alias.
             heading_level: 1
             inherited_members: true
             line_length: 80


### PR DESCRIPTION
`dpir` is an alias to `_dpir.DENOISE`. Since `_dpir` is private, it wasn't getting documented, but that's hardly helpful for the users of `dpir`, so add it to exemption filters. This is basically the same situation as `_dre_edgemask`.