### PR TITLE
docs: include vsdenoise.prefilters

### DIFF
--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -47,7 +47,6 @@ MODULES = [
 EXCLUDE = [
     # These cause infinite recursion in griffe.
     "vsdenoise.nlm",
-    "vsdenoise.prefilters",
 
     # Cannot be found.
     "vspreview.plugins.builtins.frame_props.category",


### PR DESCRIPTION
This used to cause infinite recursion, but apparently it is fine now. Maybe since `PelType` was removed and IIRC that was one of if not _the_ offending item?

![2025-03-14-14-57-06](https://github.com/user-attachments/assets/9c92db08-0ccc-47de-ae5b-90ee39edb14a)
