### PR TITLE
vskernels: Replace `__init_subclass__` by a metaclass and instantiation check

### DIFF
--- a/vsaa/abstract.py
+++ b/vsaa/abstract.py
@@ -13,7 +13,7 @@ from vstools import T, check_progressive, core, inject_self, vs, vs_object
 
 from .enums import AADirection
 
-__all__ = __abstract__ = [
+__all__ = [
     'SuperSampler',
     'SingleRater', 'DoubleRater',
     'Antialiaser'

--- a/vskernels/kernels/abstract.py
+++ b/vskernels/kernels/abstract.py
@@ -148,6 +148,11 @@ class BaseScalerMeta(ABCMeta):
         partial_abstract: bool = False,
         **kwargs: Any
     ) -> BaseScalerMeta:
+        """
+        Adding `abstract=True` to the class declaration will force the class to be abstract and not be instantiated.
+        Adding `partial_abstract=True` to the class declaration will allow the class to be instantiated
+        but will likely raise an error if the kernel radius is not implemented.
+        """
 
         obj = super().__new__(mcls, name, bases, namespace, **kwargs)
 

--- a/vskernels/kernels/abstract.py
+++ b/vskernels/kernels/abstract.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from abc import ABC, ABCMeta
 from functools import lru_cache
 from inspect import Signature
 from math import ceil
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, Sequence, TypeVar, Union, cast, overload
+
+from typing_extensions import Self
 
 from jetpytools import inject_kwargs_params
 
@@ -27,8 +30,6 @@ __all__ = [
     'Resampler', 'ResamplerT',
     'Kernel', 'KernelT'
 ]
-
-_finished_loading_abstract = False
 
 
 @lru_cache
@@ -63,7 +64,7 @@ def _base_from_param(
     basecls: type[BaseScalerT],
     value: str | type[BaseScalerT] | BaseScalerT | None,
     exception_cls: type[CustomValueError],
-    excluded: Sequence[type[BaseScalerT]] = [],
+    excluded: Sequence[type] = [],
     func_except: FuncExceptT | None = None
 ) -> type[BaseScalerT]:
     if isinstance(value, str):
@@ -110,7 +111,55 @@ def _base_ensure_obj(
     return new_scaler
 
 
-class BaseScaler(vs_object):
+def _check_kernel_radius(cls: BaseScalerMeta, obj: BaseScaler) -> BaseScaler:
+    if cls in partial_abstract_kernels:
+        return obj
+
+    if cls in abstract_kernels:
+        raise CustomRuntimeError(f"Can't instantiate abstract class {cls.__name__}!", cls)
+
+    mro = set(cls.mro())
+    mro.discard(BaseScaler)
+
+    for sub_cls in mro:
+        if any(v in sub_cls.__dict__.keys() for v in ('_static_kernel_radius', 'kernel_radius')):
+            return obj
+
+    raise CustomRuntimeError(
+        'When inheriting from BaseScaler, you must implement the kernel radius by either adding '
+        'the `kernel_radius` property or setting the class variable `_static_kernel_radius`.',
+        reason=cls
+    )
+
+
+abstract_kernels: list[BaseScalerMeta] = []
+partial_abstract_kernels: list[BaseScalerMeta] = []
+
+
+class BaseScalerMeta(ABCMeta):
+    def __new__(
+        mcls,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        /,
+        *,
+        abstract: bool = False,
+        partial_abstract: bool = False,
+        **kwargs: Any
+    ) -> BaseScalerMeta:
+
+        obj = super().__new__(mcls, name, bases, namespace, **kwargs)
+
+        if abstract:
+            abstract_kernels.append(obj)
+        elif partial_abstract:
+            partial_abstract_kernels.append(obj)
+
+        return obj
+
+
+class BaseScaler(vs_object, ABC, metaclass=BaseScalerMeta, abstract=True):
     """
     Base abstract scaling interface.
     """
@@ -121,52 +170,15 @@ class BaseScaler(vs_object):
     _static_kernel_radius: ClassVar[int]
     _err_class: ClassVar[type[CustomValueError]]
 
+    if not TYPE_CHECKING:
+        def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+            return _check_kernel_radius(cls, super().__new__(cls))
+
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
 
     def __str__(self) -> str:
         return self.pretty_string
-
-    def __init_subclass__(cls) -> None:
-        if not _finished_loading_abstract:
-            return
-
-        from ..util import abstract_kernels
-        from .complex import CustomComplexKernel
-
-        if cls in abstract_kernels:
-            return
-
-        import sys
-
-        module = sys.modules[cls.__module__]
-
-        if hasattr(module, '__abstract__'):
-            if cls.__name__ in module.__abstract__:
-                abstract_kernels.append(cls)
-                return
-
-        if 'kernel_radius' in cls.__dict__.keys():
-            return
-
-        mro = [cls, *({*cls.mro()} - {*CustomComplexKernel.mro()})]
-
-        for sub_cls in mro:
-            if hasattr(sub_cls, '_static_kernel_radius'):
-                break
-
-            try:
-                if hasattr(sub_cls, 'kernel_radius'):
-                    break
-            except Exception:
-                ...
-        else:
-            if mro:
-                raise CustomRuntimeError(
-                    'When inheriting from BaseScaler, you must implement the kernel radius by either adding '
-                    'the `kernel_radius` property or setting the class variable `_static_kernel_radius`.',
-                    reason=cls
-                )
 
     @staticmethod
     def _wh_norm(clip: vs.VideoNode, width: int | None = None, height: int | None = None) -> tuple[int, int]:
@@ -584,7 +596,6 @@ class Kernel(Scaler, Descaler, Resampler):
     def from_param(
         cls, kernel: str | type[BaseScaler] | BaseScaler | None = None, /, func_except: FuncExceptT | None = None
     ) -> type[BaseScaler]:
-        from ..util import abstract_kernels
         return _base_from_param(
             cls, Kernel, kernel, UnknownKernelError, abstract_kernels, func_except
         )
@@ -622,7 +633,6 @@ class Kernel(Scaler, Descaler, Resampler):
         cls: type[Kernel], kernel: str | type[BaseScaler] | BaseScaler | None = None, /,
         func_except: FuncExceptT | None = None
     ) -> BaseScaler:
-        from ..util import abstract_kernels
         return _base_ensure_obj(
             cls, Kernel, kernel, UnknownKernelError, abstract_kernels, func_except
         )

--- a/vskernels/kernels/placebo.py
+++ b/vskernels/kernels/placebo.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-class Placebo(ComplexScaler):
+class Placebo(ComplexScaler, abstract=True):
     """
     Abstract Placebo scaler.
 

--- a/vskernels/util.py
+++ b/vskernels/util.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 from vsexprtools import norm_expr
 from vstools import (
     ConstantFormatVideoNode, CustomRuntimeError, CustomValueError, HoldsVideoFormatT, InvalidTransferError, Matrix,
-    MatrixT, Transfer, cachedproperty, depth, get_video_format, inject_self, to_singleton, vs
+    MatrixT, Transfer, cachedproperty, depth, get_video_format, inject_self, vs
 )
 
 if TYPE_CHECKING:
@@ -18,14 +18,10 @@ if TYPE_CHECKING:
 else:
     BaseScaler = Any
 
-from .kernels import (
-    Bicubic, BicubicAuto, Catrom, ComplexKernel, CustomComplexKernel, Kernel, KernelT, LinearDescaler,
-    Placebo, Point, Resampler, ResamplerT, Scaler
-)
+from .kernels import Bicubic, Catrom, Kernel, KernelT, Point, Resampler, ResamplerT, Scaler
 from .types import Center, LeftShift, Slope, TopShift
 
 __all__ = [
-    'abstract_kernels', 'excluded_kernels',
     'NoShift', 'NoScale',
 
     'LinearLight',
@@ -126,35 +122,6 @@ class NoScale(NoScaleBase, Bicubic):
             ...
 
         return inner_no_scale
-
-
-abstract_kernels = list[type[BaseScaler]]([
-    Kernel, Placebo, ComplexKernel, CustomComplexKernel, LinearDescaler
-])
-
-
-@to_singleton
-class excluded_kernels(list[type]):
-    def __init__(self) -> None:
-        super().__init__(abstract_kernels)
-
-        self.exclude_sub = [NoShiftBase, NoScaleBase, BicubicAuto]
-
-    def __contains__(self, key: object) -> bool:
-        if not isinstance(key, type):
-            key = key.__class__
-
-        if super().__contains__(key):
-            return True
-
-        if key in self.exclude_sub:
-            return True
-
-        for t in self.exclude_sub:
-            if issubclass(key, t):
-                return True
-
-        return False
 
 
 @dataclass
@@ -290,8 +257,3 @@ def resample_to(
         return Point.resample(clip, out_fmt, matrix)
 
     return resampler.resample(clip, out_fmt, matrix)
-
-
-if True:
-    from .kernels import abstract
-    abstract._finished_loading_abstract = True

--- a/vsscale/helpers.py
+++ b/vsscale/helpers.py
@@ -21,10 +21,6 @@ __all__ = [
     'ScalingArgs'
 ]
 
-__abstract__ = [
-    'GenericScaler'
-]
-
 
 class _GeneriScaleNoShift(Protocol):
     def __call__(self, clip: vs.VideoNode, width: int, height: int, *args: Any, **kwds: Any) -> vs.VideoNode:
@@ -40,7 +36,7 @@ class _GeneriScaleWithShift(Protocol):
 
 
 @dataclass
-class GenericScaler(Scaler):
+class GenericScaler(Scaler, partial_abstract=True):
     """
     Generic Scaler base class.
     Inherit from this to create more complex scalers with built-in utils.


### PR DESCRIPTION
The current implementation of `vskernels` checks the inherited classes within the `__init_subclass__` method defined in `BaseScaler` when the classes are constructed.

However, this approach has several issues:
- The `abstract_kernels` list is hardcoded with default values in a separate location, leading to a cumbersome design where you have to wait for these abstract classes to load.
- Abstract classes are bypassed and can be instantiated by the user, even if they haven't specified a kernel radius.
- Declaring "abstract" classes in a `__abstract__` list at the top of the file is misleading and questionable. These classes aren't truly abstract since they can still be instantiated, and the kernel radius check is simply skipped.

My proposed solution:
- Add a metaclass to `BaseScaler` to explicitly define abstract classes—those that shouldn't be instantiated.
- Introduce a `partial_abstract` argument to bypass the kernel radius check, preserving the current behavior for classes like `vsscale.GenericScaler`.
- ~~Classes like `Scaler` or `Kernel` will continue to function as they did before, but they will throw an error when attempting to access `kernel_radius` (as they did previously).~~
- The `kernel_radius` check will occur during class instantiation rather than class construction, eliminating the need to explicitly add an abstract argument when defining the abstract interface.
- All logic will be contained within the same file, avoiding scattered code across multiple files.
