### PR TITLE
Kernel: Rename `multi` method to `supersample`, deprecate `multi`

### DIFF
--- a/vsdehalo/denoise.py
+++ b/vsdehalo/denoise.py
@@ -201,7 +201,7 @@ def vine_dehalo(
     weight = constants0 * log(1 + 1 / constants0)
     h_refine = [constants1 * (s / constants1) ** constants2 for s in strength]
 
-    supersampled = supersampler.multi(func.work_clip)
+    supersampled = supersampler.supersample(func.work_clip)
     supersampled = nl_means(supersampled, strength, tr=0, simr=0, **kwargs)
     supersampled = downscaler.scale(supersampled, func.work_clip.width, func.work_clip.height)
 

--- a/vskernels/kernels/abstract.py
+++ b/vskernels/kernels/abstract.py
@@ -298,7 +298,7 @@ class Scaler(BaseScaler):
         )
 
     def get_implemented_funcs(self) -> tuple[Callable[..., Any], ...]:
-        return (self.scale, self.multi)
+        return (self.scale, self.supersample)
 
 
 class Descaler(BaseScaler):

--- a/vskernels/kernels/abstract.py
+++ b/vskernels/kernels/abstract.py
@@ -255,19 +255,31 @@ class Scaler(BaseScaler):
         )
 
     @inject_self.cached
-    def multi(
-        self, clip: vs.VideoNode, multi: float = 2, shift: tuple[TopShift, LeftShift] = (0, 0), **kwargs: Any
+    def supersample(
+        self, clip: vs.VideoNode, rfactor: float = 2.0, shift: tuple[TopShift, LeftShift] = (0, 0), **kwargs: Any
     ) -> vs.VideoNode:
         assert check_variable_resolution(clip, self.multi)
 
-        dst_width, dst_height = ceil(clip.width * multi), ceil(clip.height * multi)
+        dst_width, dst_height = ceil(clip.width * rfactor), ceil(clip.height * rfactor)
 
         if max(dst_width, dst_height) <= 0.0:
             raise CustomValueError(
-                'Multiplying the resolution by "multi" must result in a positive resolution!', self.multi, multi
+                'Multiplying the resolution by "rfactor" must result in a positive resolution!', self.supersample, rfactor
             )
 
         return self.scale(clip, dst_width, dst_height, shift, **kwargs)
+
+    @inject_self.cached
+    def multi(
+        self, clip: vs.VideoNode, rfactor: float = 2.0, shift: tuple[TopShift, LeftShift] = (0, 0), **kwargs: Any
+    ) -> vs.VideoNode:
+
+        import warnings
+
+        warnings.warn('The "multi" method is deprecated. Use "supersample" instead.', DeprecationWarning)
+
+        return self.supersample(clip, rfactor, shift, **kwargs)
+
 
     @inject_kwargs_params
     def get_scale_args(

--- a/vsscale/rescale.py
+++ b/vsscale/rescale.py
@@ -123,7 +123,7 @@ class RescaleBase:
 
     @_add_props
     def _generate_doubled(self, clip: ConstantFormatVideoNode) -> ConstantFormatVideoNode:
-        return self.upscaler.multi(clip, 2)  # type: ignore[return-value]
+        return self.upscaler.supersample(clip, 2)  # type: ignore[return-value]
 
     @_add_props
     def _generate_upscale(self, clip: ConstantFormatVideoNode) -> ConstantFormatVideoNode:


### PR DESCRIPTION
Minor changes across the codebase. `supersample` makes more intuitive sense to me than `multi`, and this method is also called by a `supersampler` scaler in other places.