### PR TITLE
docs: Enable inventory generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
       nav_file: SUMMARY.md
   - mkdocstrings:
       custom_templates: docs/templates
+      enable_inventory: true
       handlers:
         python:
           inventories:


### PR DESCRIPTION
Crazy PR.

Allows you to import the inventory in other docs sites to reference types and functions and link back to this one.