### PR TITLE
FixInterlacedFades: fix pure-$targetcolor field handling bug

### DIFF
--- a/vsdeinterlace/funcs.py
+++ b/vsdeinterlace/funcs.py
@@ -199,7 +199,7 @@ class FixInterlacedFades(CustomEnum):
         )
 
         expr_header = 'Y 2 % x.fbAvg{i} x.ftAvg{i} ? AVG! AVG@ 0 = x x {color} - '
-        expr_footer = ' AVG@ / * ? {color} +'
+        expr_footer = ' AVG@ / * {color} + ?'
 
         expr_luma = expr_header + 'x.ftAvg{i} x.fbAvg{i} {expr_mode}' + expr_footer
         expr_chroma = expr_luma if self == self.Average else (


### PR DESCRIPTION
Due to a mistake in the operation order, fields whose average exactly matches the desired target color were getting their values added to $color (effectively multiplied by two in case of pure-color fields), resulting in very wrong output except for fades to/from black.