### PR TITLE
Remove `bmdegrain` from vsdenoise

### DIFF
--- a/vsdenoise/blockmatch.py
+++ b/vsdenoise/blockmatch.py
@@ -21,7 +21,6 @@ from .prefilters import Prefilter
 
 __all__ = [
     'wnnm',
-    'bmdegrain',
     'bm3d'
 ]
 
@@ -143,86 +142,6 @@ def wnnm(
                 sigma=sigma, block_size=block_size, block_step=block_step, group_size=group_size,
                 bm_range=bm_range, radius=tr, ps_num=ps_num, ps_range=ps_range, rclip=ref,
                 adaptive_aggregation=adaptive_aggregation, residual=residual
-            )
-        )
-    )
-
-
-def bmdegrain(
-    clip: vs.VideoNode, sigma: float | list[float] = 3.0,
-    refine: int = 0, tr: int = 0, ref: vs.VideoNode | Prefilter | None = None,
-    block_size: int = 8, block_step: int = 8, group_size: int = 8,
-    bm_range: int = 7, ps_num: int = 2, ps_range: int = 4,
-    merge_factor: float = 0.1, self_refine: bool = False, planes: PlanesT = None
-) -> vs.VideoNode:
-    """
-    BM3D and mvtools inspired denoiser.
-
-    :param clip:                    Clip to process.
-    :param sigma:                   Strength of denoising, valid range is [0, +inf].
-                                    If a float is passed, this strength will be applied to every plane.
-                                    Values higher than 4.0 are not recommended. Recommended values are [0.35, 1.0].
-                                    Default: 3.0.
-    :param refine:                  The amount of iterations for iterative regularization.
-                                    Default: 0.
-    :param ref:                     Reference clip. Must be the same dimensions and format as input clip.
-                                    Alternatively, a :py:class:`Prefilter` can be passed.
-                                    Default: None.
-    :param block_size:              The size of a block. Blocks are basic processing units.
-                                    Larger blocks will take more time to process, but combined with `block_step`,
-                                    may result in fewer blocks being processed overall.
-                                    Valid ranges are [1, 64]. Default: 8.
-    :param block_step:              Sliding step to process every next reference block.
-                                    The total amount of blocks to process can be calculated with the following equation:
-                                    `(width / block_step) * (height / block_step)`.
-                                    Smaller values results in more reference blocks being processed.
-                                    Default: 8.
-    :param group_size:              Maximum number of similar blocks allowed per group (the 3rd dimension).
-                                    Valid range is [1, 256]. By allowing more similar blocks to be grouped together,
-                                    fewer blocks will be given to a transformed group,
-                                    increasing the denoising strength.
-                                    Setting this to 1 means no block matching will be performed.
-                                    Default: 8.
-    :param bm_range:                Length of the side of the searching neighborhood. Valid range is [0, +inf].
-                                    The size of the search window is `(bm_range * 2 + 1) x (bm_range * 2 + 1)`.
-                                    Larger values take more time to process, but increases the likelihood
-                                    of finding similar patches.
-                                    Default: 7.
-    :param ps_num:                  The number of matched locations used for the predictive search.
-                                    Valid ranges are [1, `group_size`].
-                                    Larger values increases the possibility to match similar blocks,
-                                    at the cost of taking more processing power.
-                                    Default: 2.
-    :param ps_range:                Length of the side of the search neighborhood for `pd_num`.
-                                    Valid range is [1, +inf]. Default: 4.
-    :param merge_factor:            Merge amount of the last recalculation into the new one
-                                    when performing iterative regularization.
-    :param self_refine:             If True, in the iterative recalculation step it will pass the
-                                    last recalculation as ref clip instead of the original ``ref``.
-    :param planes:                  Planes to process. If None, all planes. Default: None.
-
-    :return:                        Denoised clip.
-    """
-
-    assert check_progressive(clip, bmdegrain)
-
-    func = FunctionUtil(clip, bmdegrain, planes, bitdepth=32)
-
-    sigma = func.norm_seq(sigma, 0)
-
-    if isinstance(ref, Prefilter):
-        ref = ref(func.work_clip, planes)
-    elif ref is not None:
-        ref = depth(ref, 32)
-        ref = get_y(ref) if func.luma_only else ref
-        check_ref_clip(clip, ref, func.func)
-
-    return func.return_clip(
-        _recursive_denoise(
-            func.work_clip, core.bmdegrain.BMDegrain, self_refine and 'rclip' or None,
-            refine, merge_factor, planes, dict(
-                th_sse=sigma, block_size=block_size, block_step=block_step, group_size=group_size,
-                bm_range=bm_range, radius=tr, ps_num=ps_num, ps_range=ps_range, rclip=ref
             )
         )
     )


### PR DESCRIPTION
As stated on the Github page, it's still under development.

Draft for now until https://github.com/Jaded-Encoding-Thaumaturgy/vs-jetpack/pull/80 is merged as I don't want to fix annoying conflicts