### PR TITLE
vsexprtools: add missing operators

### DIFF
--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -404,7 +404,7 @@ class ExprOp(ExprOpBase, CustomEnum):
 
     @classmethod
     def acos(cls, c: SupportsString = "", n: int = 5) -> ExprList:
-        return ExprList([cls.PI, 2, ExprOp.DIV, cls.asin(c, n), ExprOp.SUB])
+        return ExprList([c, "acosvar!", cls.PI, 2, ExprOp.DIV, cls.asin("acosvar@", n), ExprOp.SUB])
 
     @classmethod
     def clamp(

--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -206,7 +206,14 @@ class ExprOpBase(str):
 
 
 class ExprOp(ExprOpBase, CustomEnum):
-    # 1 Argument
+    # 0 Argument (akarin)
+    N = "N", 0
+    X = "X", 0
+    Y = "Y", 0
+    WIDTH = "width", 0
+    HEIGHT = "height", 0
+
+    # 1 Argument (std)
     EXP = "exp", 1
     LOG = "log", 1
     SQRT = "sqrt", 1
@@ -215,12 +222,19 @@ class ExprOp(ExprOpBase, CustomEnum):
     ABS = "abs", 1
     NOT = "not", 1
     DUP = "dup", 1
-    DUPN = "dupN", 1
+    DUPN = "dup{N:d}", 1
+    # 1 Argument (akarin)
     TRUNC = "trunc", 1
     ROUND = "round", 1
     FLOOR = "floor", 1
+    DROP = "drop", 1
+    DROPN = "drop{N:d}", 1
+    SORT = "sort", 1
+    SORTN = "sort{N:d}", 1
+    VAR_STORE = "{name:s}!", 1
+    VAR_PUSH = "{name:s}@", 1
 
-    # 2 Arguments
+    # 2 Arguments (std)
     MAX = "max", 2
     MIN = "min", 2
     ADD = "+", 2
@@ -237,11 +251,13 @@ class ExprOp(ExprOpBase, CustomEnum):
     OR = "or", 2
     XOR = "xor", 2
     SWAP = "swap", 2
-    SWAPN = "swapN", 2
+    SWAPN = "swap{N:d}", 2
+    # 2 Argument (akarin)
     MOD = "%", 2
 
-    # 3 Arguments
+    # 3 Arguments (std)
     TERN = "?", 3
+    # 3 Argument (akarin)
     CLAMP = "clamp", 3
 
     # Special Operators

--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -327,6 +327,7 @@ class ExprOp(ExprOpBase, metaclass=ExprOpExtraMeta):
     def is_extra(self) -> bool:
         return self.name in ExprOp._extra_op_names_
 
+    @cache
     def convert_extra(self) -> str:
         if not self.is_extra():
             raise ValueError

--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import cycle
-from math import isqrt
+from math import isqrt, pi
 from typing import Any, Iterable, Iterator, Sequence, SupportsFloat, SupportsIndex, overload
 
 from jetpytools import CustomRuntimeError
@@ -264,6 +264,12 @@ class ExprOp(ExprOpBase, CustomEnum):
     REL_PIX = "{char:s}[{x:d},{y:d}]", 3
     ABS_PIX = "{x:d} {y:d} {char:s}[]", 3
 
+    # Not Implemented in akarin or std
+    PI = str(pi), 0
+    SGN = "dup 0 > swap 0 < -", 1
+    NEG = "-1 *", 1
+    TAN = "dup sin swap cos /", 1
+
     @overload
     def __call__(
         self,
@@ -311,6 +317,66 @@ class ExprOp(ExprOpBase, CustomEnum):
 
     def __mul__(self, n: int) -> list[ExprOp]:  # type: ignore[override]
         return [self] * n
+
+    @classmethod
+    def atan(cls, c: str = "x", n: int = 5) -> ExprList:
+        # Using domain reduction when |x| > 1
+        expr = ExprList([
+            ExprList([c, ExprOp.DUP, "atanvar!", ExprOp.ABS, 1, ExprOp.GT]),
+            ExprList([
+                "atanvar@", ExprOp.SGN, ExprOp.PI, ExprOp.MUL, 2, ExprOp.DIV,
+                1, "atanvar@", ExprOp.DIV, cls.atanf("", n), ExprOp.SUB]
+                ),
+            ExprList([cls.atanf("atanvar@", n)]),
+            ExprOp.TERN
+        ])
+
+        return expr
+
+    @classmethod
+    def atanf(cls, c: str = "x", n: int = 5) -> ExprList:
+        # Approximation using Taylor series
+        n = max(2, n)
+
+        expr = ExprList([c, ExprOp.DUP, "atanfvar!"])
+
+        for i in range(1, n):
+            expr.append("atanfvar@", 2 * i + 1, ExprOp.POW, 2 * i + 1, ExprOp.DIV, ExprOp.SUB if i % 2 else ExprOp.ADD)
+
+        return expr
+
+    @classmethod
+    def atan2(cls, y: str = "y", x: str = "x", n: int = 5) -> ExprList:
+        expr = ExprList([
+            ExprList([x, 0, ExprOp.EQ]),  # if x = 0
+            ExprList([ExprOp.PI, 2, ExprOp.DIV, y, ExprOp.SGN, ExprOp.MUL]),
+            ExprList([
+                # if x != 0
+                cls.atan(ExprList([y, x, ExprOp.DIV]).to_str(), n),  # atan(y/x)
+                    ExprList([x, 0, ExprOp.GT]),                     # if x > 0
+                    0,
+                    ExprList([
+                        ExprList([y, 0, ExprOp.GTE]),                # if y >= 0
+                        ExprOp.PI,
+                        "-" + ExprOp.PI,                             # if y < 0
+                        ExprOp.TERN
+                    ]),
+                    ExprOp.TERN,
+                ExprOp.ADD                                           # Add atan(y/x) + (-)pi
+            ]),
+            ExprOp.TERN
+        ])
+        return expr
+
+    @classmethod
+    def asin(cls, c: str = "x", n: int = 5) -> ExprList:
+        return cls.atan(
+            ExprList([c, ExprOp.DUP, ExprOp.DUP, ExprOp.MUL, 1, ExprOp.SWAP, ExprOp.SUB, ExprOp.SQRT, ExprOp.DIV]).to_str(), n
+        )
+
+    @classmethod
+    def acos(cls, c: str = "x", n: int = 5) -> ExprList:
+        return ExprList([cls.PI, 2, ExprOp.DIV, cls.asin(c, n), ExprOp.SUB])
 
     @classmethod
     def clamp(

--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -35,11 +35,7 @@ from .util import ExprVarRangeT, ExprVars, ExprVarsT, complexpr_available
 __all__ = ["ExprList", "ExprOp", "ExprToken", "TupleExprList"]
 
 
-class ExprTokenBase(str):
-    value: str
-
-
-class ExprToken(ExprTokenBase, CustomEnum):
+class ExprToken(CustomStrEnum):
     LumaMin = "ymin"
     ChromaMin = "cmin"
     LumaMax = "ymax"
@@ -124,8 +120,8 @@ class ExprToken(ExprTokenBase, CustomEnum):
 
         raise CustomValueError("You are using an unsupported ExprToken!", self.get_value, self)
 
-    def __getitem__(self, i: SupportsIndex) -> ExprToken:  # type: ignore
-        return ExprTokenBase(f"{self.value}_{ExprVars[i]}")  # type: ignore
+    def __getitem__(self, i: int) -> str:  # type: ignore[override]
+        return f"{self._value_}_{ExprVars[i]}"
 
 
 class ExprList(StrList):
@@ -189,6 +185,8 @@ class ExprOpBase(CustomStrEnum):
         self.n_op = n_op
 
         return self
+
+    __str__ = str.__str__
 
     @overload
     def __call__(

--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -7,6 +7,8 @@ from typing import Any, Iterable, Iterator, Sequence, SupportsFloat, SupportsInd
 from jetpytools import CustomRuntimeError
 from typing_extensions import Self
 
+from jetpytools import SupportsString
+
 from vstools import (
     ColorRange,
     ConstantFormatVideoNode,
@@ -319,22 +321,35 @@ class ExprOp(ExprOpBase, CustomEnum):
         return [self] * n
 
     @classmethod
-    def atan(cls, c: str = "x", n: int = 5) -> ExprList:
+    def atan(cls, c: SupportsString = "", n: int = 5) -> ExprList:
         # Using domain reduction when |x| > 1
-        expr = ExprList([
-            ExprList([c, ExprOp.DUP, "atanvar!", ExprOp.ABS, 1, ExprOp.GT]),
-            ExprList([
-                "atanvar@", ExprOp.SGN, ExprOp.PI, ExprOp.MUL, 2, ExprOp.DIV,
-                1, "atanvar@", ExprOp.DIV, cls.atanf("", n), ExprOp.SUB]
+        expr = ExprList(
+            [
+                ExprList([c, ExprOp.DUP, "atanvar!", ExprOp.ABS, 1, ExprOp.GT]),
+                ExprList(
+                    [
+                        "atanvar@",
+                        ExprOp.SGN,
+                        ExprOp.PI,
+                        ExprOp.MUL,
+                        2,
+                        ExprOp.DIV,
+                        1,
+                        "atanvar@",
+                        ExprOp.DIV,
+                        cls.atanf("", n),
+                        ExprOp.SUB,
+                    ]
                 ),
-            ExprList([cls.atanf("atanvar@", n)]),
-            ExprOp.TERN
-        ])
+                ExprList([cls.atanf("atanvar@", n)]),
+                ExprOp.TERN,
+            ]
+        )
 
         return expr
 
     @classmethod
-    def atanf(cls, c: str = "x", n: int = 5) -> ExprList:
+    def atanf(cls, c: SupportsString = "", n: int = 5) -> ExprList:
         # Approximation using Taylor series
         n = max(2, n)
 
@@ -346,37 +361,49 @@ class ExprOp(ExprOpBase, CustomEnum):
         return expr
 
     @classmethod
-    def atan2(cls, y: str = "y", x: str = "x", n: int = 5) -> ExprList:
-        expr = ExprList([
-            y, x, "atan2xvar!", "atan2yvar!",
-            ExprList(["atan2xvar@", 0, ExprOp.EQ]),                                        # if x = 0
-            ExprList([ExprOp.PI, 2, ExprOp.DIV, "atan2yvar@", ExprOp.SGN, ExprOp.MUL]),
-            ExprList([
-                # if x != 0
-                cls.atan(ExprList(["atan2yvar@", "atan2xvar@", ExprOp.DIV]).to_str(), n),  # atan(y/x)
-                    ExprList(["atan2xvar@", 0, ExprOp.GT]),                                # if x > 0
-                    0,
-                    ExprList([
-                        ExprList(["atan2yvar@", 0, ExprOp.GTE]),                           # if y >= 0
-                        ExprOp.PI,
-                        "-" + ExprOp.PI,                                                   # if y < 0
-                        ExprOp.TERN
-                    ]),
-                    ExprOp.TERN,
-                ExprOp.ADD                                                                 # Add atan(y/x) + (-)pi
-            ]),
-            ExprOp.TERN
-        ])
+    def atan2(cls, y: SupportsString = "", x: SupportsString = "", n: int = 5) -> ExprList:
+        expr = ExprList(
+            [
+                y,
+                x,
+                "atan2xvar!",
+                "atan2yvar!",
+                ExprList(["atan2xvar@", 0, ExprOp.EQ]),  # if x = 0
+                ExprList([ExprOp.PI, 2, ExprOp.DIV, "atan2yvar@", ExprOp.SGN, ExprOp.MUL]),
+                ExprList(
+                    [
+                        # if x != 0
+                        cls.atan(ExprList(["atan2yvar@", "atan2xvar@", ExprOp.DIV]).to_str(), n),  # atan(y/x)
+                        ExprList(["atan2xvar@", 0, ExprOp.GT]),  # if x > 0
+                        0,
+                        ExprList(
+                            [
+                                ExprList(["atan2yvar@", 0, ExprOp.GTE]),  # if y >= 0
+                                ExprOp.PI,
+                                "-" + ExprOp.PI,  # if y < 0
+                                ExprOp.TERN,
+                            ]
+                        ),
+                        ExprOp.TERN,
+                        ExprOp.ADD,  # Add atan(y/x) + (-)pi
+                    ]
+                ),
+                ExprOp.TERN,
+            ]
+        )
         return expr
 
     @classmethod
-    def asin(cls, c: str = "x", n: int = 5) -> ExprList:
+    def asin(cls, c: SupportsString = "", n: int = 5) -> ExprList:
         return cls.atan(
-            ExprList([c, ExprOp.DUP, ExprOp.DUP, ExprOp.MUL, 1, ExprOp.SWAP, ExprOp.SUB, ExprOp.SQRT, ExprOp.DIV]).to_str(), n
+            ExprList(
+                [c, ExprOp.DUP, ExprOp.DUP, ExprOp.MUL, 1, ExprOp.SWAP, ExprOp.SUB, ExprOp.SQRT, ExprOp.DIV]
+            ).to_str(),
+            n,
         )
 
     @classmethod
-    def acos(cls, c: str = "x", n: int = 5) -> ExprList:
+    def acos(cls, c: SupportsString = "", n: int = 5) -> ExprList:
         return ExprList([cls.PI, 2, ExprOp.DIV, cls.asin(c, n), ExprOp.SUB])
 
     @classmethod

--- a/vsexprtools/exprop.py
+++ b/vsexprtools/exprop.py
@@ -348,21 +348,22 @@ class ExprOp(ExprOpBase, CustomEnum):
     @classmethod
     def atan2(cls, y: str = "y", x: str = "x", n: int = 5) -> ExprList:
         expr = ExprList([
-            ExprList([x, 0, ExprOp.EQ]),  # if x = 0
-            ExprList([ExprOp.PI, 2, ExprOp.DIV, y, ExprOp.SGN, ExprOp.MUL]),
+            y, x, "atan2xvar!", "atan2yvar!",
+            ExprList(["atan2xvar@", 0, ExprOp.EQ]),                                        # if x = 0
+            ExprList([ExprOp.PI, 2, ExprOp.DIV, "atan2yvar@", ExprOp.SGN, ExprOp.MUL]),
             ExprList([
                 # if x != 0
-                cls.atan(ExprList([y, x, ExprOp.DIV]).to_str(), n),  # atan(y/x)
-                    ExprList([x, 0, ExprOp.GT]),                     # if x > 0
+                cls.atan(ExprList(["atan2yvar@", "atan2xvar@", ExprOp.DIV]).to_str(), n),  # atan(y/x)
+                    ExprList(["atan2xvar@", 0, ExprOp.GT]),                                # if x > 0
                     0,
                     ExprList([
-                        ExprList([y, 0, ExprOp.GTE]),                # if y >= 0
+                        ExprList(["atan2yvar@", 0, ExprOp.GTE]),                           # if y >= 0
                         ExprOp.PI,
-                        "-" + ExprOp.PI,                             # if y < 0
+                        "-" + ExprOp.PI,                                                   # if y < 0
                         ExprOp.TERN
                     ]),
                     ExprOp.TERN,
-                ExprOp.ADD                                           # Add atan(y/x) + (-)pi
+                ExprOp.ADD                                                                 # Add atan(y/x) + (-)pi
             ]),
             ExprOp.TERN
         ])

--- a/vsexprtools/funcs.py
+++ b/vsexprtools/funcs.py
@@ -28,7 +28,7 @@ from vstools import (
 )
 
 from .exprop import ExprList, ExprOp, ExprOpBase, TupleExprList
-from .util import ExprVars, bitdepth_aware_tokenize_expr, complexpr_available, norm_expr_planes
+from .util import ExprVars, bitdepth_aware_tokenize_expr, complexpr_available, extra_op_tokenize_expr, norm_expr_planes
 
 __all__ = ["combine", "expr_func", "norm_expr"]
 
@@ -188,4 +188,6 @@ def norm_expr(
         bitdepth_aware_tokenize_expr(clips, e, bool(is_chroma)) for is_chroma, e in enumerate(normalized_expr)
     ]
 
-    return expr_func(clips, tokenized_expr, format, opt, boundary, func)
+    extra_op_expr = [extra_op_tokenize_expr(e) for e in tokenized_expr]
+
+    return expr_func(clips, extra_op_expr, format, opt, boundary, func)

--- a/vsexprtools/util.py
+++ b/vsexprtools/util.py
@@ -263,7 +263,7 @@ def bitdepth_aware_tokenize_expr(
     clips = list(clips)
     ranges = [ColorRange.from_video(c, func=func) for c in clips]
 
-    mapped_clips = list(reversed(list(zip(["", *EXPR_VARS], clips[:1] + clips, ranges[:1] + ranges))))
+    mapped_clips = reversed(list(zip(["", *EXPR_VARS], clips[:1] + clips, ranges[:1] + ranges)))
 
     for mkey, function in replaces:
         if mkey in expr:
@@ -294,5 +294,5 @@ def norm_expr_planes(
 
     return [
         exp.format(**({"plane_idx": i} | {key: value[i] for key, value in string_args})) if i in planes else ""
-        for i, exp in enumerate(expr_array, 0)
+        for i, exp in enumerate(expr_array)
     ]


### PR DESCRIPTION
- `tan`, `atan`, `atan2`, `asin`, `acos`, `pi`, `neg`, `sgn` are not available in std nor akarin. Equivalents have been added.
- `dupN`, `drop`,  `dropN`, `sort,` `sortN`, `var_store`, `var_push`, `swapN` have been added to ExprOp

Closes #67. 