### PR TITLE
Grainfactory and film_grain_plus basic implementations

### DIFF
--- a/vsdeband/filmgrain/config.py
+++ b/vsdeband/filmgrain/config.py
@@ -1,0 +1,215 @@
+import enum
+import math
+from dataclasses import dataclass, field, replace
+from typing import Callable, Self
+
+from vstools import (
+    scale_value,
+    vs,
+)
+
+from ..noise import Grainer
+
+__all__ = [
+    "FilmGrainConfig",
+    "FilmGrainThresholds",
+    "GrainConfig",
+    "MergeStrengths",
+    "MergeStrengths",
+    "MergeType",
+    "Multiplier",
+    "PlaneStrength",
+    "ResolutionScalingPolicy",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class GrainConfig:
+    strength: float | tuple[float, float]
+    sharpness: int
+    size: float
+    grainer: Grainer | Callable
+    temporal_blur: float = 0.0
+    bump: float = 0.0
+    blur: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class Multiplier:
+    dark: float
+    mid: float
+    bright: float
+
+
+class MergeType(enum.Enum):
+    GAMMA = "gamma"
+    LINEAR = "linear"
+    LOG = "log"
+
+    def get_strength_multipliers(self, dark: float, mid: float, bright: float) -> tuple[float, float, float]:
+
+        match self:
+            case MergeType.GAMMA:
+                return dark * 1.5, mid * 1.0, bright * 0.8
+            case MergeType.LINEAR:
+                return dark * 1.0, mid * 1.0, bright * 1.0
+            case MergeType.LOG:
+                return dark * 0.7, mid * 1.2, bright * 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class FilmGrainThresholds:
+
+    th1: int = 45
+    th2: int = 85
+    th3: int = 140
+    th4: int = 200
+
+    def to_scaled(self, clip: vs.VideoNode) -> tuple[float, float, float, float]:
+        fmt = clip.format
+        assert fmt, "Clip format must be defined"
+        return tuple(
+            scale_value(
+                x,
+                8,
+                fmt.bits_per_sample, # type: ignore
+                vs.ColorRange.RANGE_FULL
+            )
+            for x in (self.th1, self.th2, self.th3, self.th4)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneStrength:
+    y: float = 1.0
+    u: float = 1.0
+    v: float = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class MergeStrengths:
+
+    dark: PlaneStrength = field(default_factory=PlaneStrength)
+    mid: PlaneStrength = field(default_factory=PlaneStrength)
+    bright: PlaneStrength = field(default_factory=PlaneStrength)
+
+    @property
+    def max_strength_y(self) -> float:
+        return max(self.dark.y, self.mid.y, self.bright.y)
+
+    def scale(self, factor: float) -> Self:
+        return replace(
+            self,
+            dark=replace(self.dark, y=self.dark.y * factor, u=self.dark.u * factor, v=self.dark.v * factor),
+            mid=replace(self.mid, y=self.mid.y * factor, u=self.mid.u * factor, v=self.mid.v * factor),
+            bright=replace(self.bright, y=self.bright.y * factor, u=self.bright.u * factor, v=self.bright.v * factor),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionScalingPolicy:
+    enable: bool = True
+
+    def strength(self, width: int) -> float:
+        # ~1.0 @ 1920, ~1.79 @ 3840
+        return 0.409 * (width * 0.001) + 0.214
+
+    def size(self, width: int) -> float:
+        # ~1.0 @ 1920, ~1.33 @ 3840
+        return 0.173 * (width * 0.001) + 0.667
+
+    def sharpness(self, width: int) -> float:
+        # ~1.0 @ 1920, ~0.34 @ 3840
+        return max(min(-0.347 * (width * 0.001) + 1.667, 1.0), 0.2)
+
+    @dataclass(frozen=True, slots=True)
+    class Result:
+        strengths: MergeStrengths
+        size: float
+        sharpness: int
+        bump: float
+        gen_strength: tuple[float, float]
+
+    def apply(
+        self,
+        clip: vs.VideoNode,
+        strengths: MergeStrengths,
+        size: float,
+        sharpness: int,
+        bump: float,
+        gen_strength: tuple[float, float],
+        s16mm: bool = False,
+    ) -> Result:
+
+        if not self.enable:
+            return ResolutionScalingPolicy.Result(strengths, size, sharpness, bump, gen_strength)
+
+        w = clip.width
+
+        strength_factor = self.strength(w)
+
+        if s16mm:
+            strength_factor *= 1.25
+
+        if bump > 1.0:
+            strength_factor /= math.sqrt(bump)
+
+        scaled_strengths: MergeStrengths = strengths.scale(strength_factor)
+
+        scaled_size = size * self.size(w)
+
+        if s16mm:
+            scaled_size = 1.5 * scaled_size + 0.5
+
+        sharp01 = max(0.0, min(1.0, sharpness / 100.0))
+        sharp01 = max(0.0, min(1.0, sharp01 * self.sharpness(w)))
+
+        if s16mm:
+            sharp01 *= 0.90
+
+        scaled_sharpness = round(max(0.0, min(1.0, sharp01)) * 100)
+
+        gen_y, gen_c = gen_strength
+        scaled_gen = (gen_y * strength_factor, gen_c * strength_factor)
+
+        return ResolutionScalingPolicy.Result(
+            strengths=scaled_strengths,
+            size=scaled_size,
+            sharpness=scaled_sharpness,
+            bump=bump,
+            gen_strength=scaled_gen,
+        )
+
+
+@dataclass
+class FilmGrainConfig:
+    strength: tuple[float, float] = (1.2, 0.5)
+    merge: MergeStrengths = field(default_factory=MergeStrengths)
+    size: float = 1.2
+    sharpness: int = 66
+    preblur: float = 1.0
+    temporal_blur: float | tuple[float, int] = (0.0, 0)
+    bump: float = 0.0
+    grainer: Grainer | Callable = Grainer.GAUSS
+    merge_type: MergeType = MergeType.GAMMA
+    deterministic: bool = True
+    thresholds: FilmGrainThresholds = field(default_factory=FilmGrainThresholds)
+    resolution_policy: ResolutionScalingPolicy = field(default_factory=ResolutionScalingPolicy)
+    seed: int = 17
+    fast: bool = False
+    s16mm: bool = False
+
+
+    def apply_preset(self: Self, preset: Self) -> Self:
+        return replace(self, **vars(preset))
+
+    def with_overrides(self, param_mapping: dict, **kwargs) -> Self:
+
+        updates = {}
+        for key, value in kwargs.items():
+            if mapper := param_mapping.get(key):
+                updates.update(mapper(value))
+            elif hasattr(self, key):
+                updates[key] = value
+
+        return replace(self, **updates)

--- a/vsdeband/filmgrain/functions.py
+++ b/vsdeband/filmgrain/functions.py
@@ -1,0 +1,155 @@
+from dataclasses import replace
+from typing import Callable
+
+from vsexprtools import inline_expr
+from vsrgtools import remove_grain
+from vstools import (
+    core,
+    get_neutral_value,
+    get_peak_value,
+    scale_value,
+    vs,
+)
+
+from ..noise import Grainer
+from .config import (
+    FilmGrainConfig,
+    FilmGrainThresholds,
+    GrainConfig,
+    MergeStrengths,
+    MergeType,
+    PlaneStrength,
+    ResolutionScalingPolicy,
+)
+from .generator import FilmGrainProcessor, GrainLayerFactory
+from .helpers import Signature
+from .presets import FilmGrainPreset
+
+__all__ = [
+    "film_grain_plus",
+    "film_grain_plus_cfg",
+    "grain_factory",
+]
+
+
+def film_grain_plus_cfg(clip: vs.VideoNode, cfg: FilmGrainConfig, debug: bool = False) -> vs.VideoNode:
+    processor = FilmGrainProcessor(cfg)
+    return processor.process(clip, debug)
+
+
+def film_grain_plus(
+    clip: vs.VideoNode,
+    strength: tuple[float, float] = (0.2, 0.1),
+    merge: MergeStrengths = MergeStrengths(
+        dark=PlaneStrength(1.0, 1.0, 1.0),
+        mid=PlaneStrength(1.0, 1.0, 1.0),
+        bright=PlaneStrength(1.0, 1.0, 1.0),
+    ),
+    size: float = 1.2,
+    sharpness: int = 66,
+    bump: float = 0.0,
+    grainer: Grainer | Callable = Grainer.GAUSS,
+    seed: int = 17,
+    preset: FilmGrainPreset | None = None,
+    mode: MergeType = MergeType.GAMMA,
+    thresholds: FilmGrainThresholds = FilmGrainThresholds(th1=45, th2=85, th3=140, th4=200),
+    resolution_policy: bool = True,
+    temporal_blur: float | tuple[float, int] = (0.0, 0),
+    preblur: float | bool = False,
+    deterministic: bool = False,
+    fast: bool = False,
+    debug: bool = False,
+    s16mm: bool = False,
+) -> vs.VideoNode:
+
+    settings = FilmGrainConfig(
+        strength=strength,
+        size=size,
+        sharpness=sharpness,
+        bump=bump,
+        grainer=grainer,
+        seed=seed,
+        temporal_blur=temporal_blur,
+        fast=fast,
+        thresholds=thresholds,
+        merge=merge,
+        merge_type=mode,
+        resolution_policy=ResolutionScalingPolicy(enable=resolution_policy),
+        deterministic=deterministic,
+        preblur=preblur,
+        s16mm=s16mm,
+    )
+
+    sig = Signature.generate(film_grain_plus, settings)
+    user_overrides = sig.changed
+
+    if preset is not None:
+        settings = settings.apply_preset(preset.value)
+
+    settings = replace(settings, **user_overrides)
+
+    return FilmGrainProcessor(settings).process(clip, debug)
+
+
+def grain_factory(
+    clip: vs.VideoNode,
+    dark_grain: GrainConfig = GrainConfig(strength=7.0, sharpness=60, size=1.5, grainer=Grainer.GAUSS),
+    mid_grain: GrainConfig = GrainConfig(strength=5.0, sharpness=66, size=1.2, grainer=Grainer.GAUSS),
+    bright_grain: GrainConfig = GrainConfig(strength=3.0, sharpness=80, size=0.9, grainer=Grainer.GAUSS),
+    seed: int = 17,
+    th1: int = 24,
+    th2: int = 56,
+    th3: int = 128,
+    th4: int = 160,
+    blur: bool = True,
+) -> vs.VideoNode:
+    neutral = get_neutral_value(clip)
+    peak = get_peak_value(clip)
+
+    th1, th2, th3, th4 = [
+        scale_value(
+            x,
+            8,
+            clip.format.bits_per_sample,  # type: ignore
+            vs.ColorRange.RANGE_FULL,
+        )
+        for x in [th1, th2, th3, th4]
+    ]
+
+    factory = GrainLayerFactory()
+    grain = [
+        factory.create(
+            clip,
+            grain,
+            seed,
+            True,
+            i + 1
+        )
+        for i, grain in enumerate([dark_grain, mid_grain, bright_grain])
+    ]
+
+    with inline_expr([clip, *grain]) as ie:
+        x, grain1, grain2, grain3 = ie.vars
+
+        ramp1 = (peak / (th2 - th1)) * (x - th1)
+        m1 = ie.op.tern(x < th1, 0, ie.op.tern(x > th2, peak, ramp1))
+
+        ramp2 = (peak / (th4 - th3)) * (x - th3)
+        m2 = ie.op.tern(x < th3, 0, ie.op.tern(x > th4, peak, ramp2))
+
+        fm = grain1 + ((grain2 - grain1) * m1 + peak / 2) / peak
+        blended = fm + ((grain3 - fm) * m2 + peak / 2) / peak
+
+        if blur:
+            ie.out = x - blended
+
+        ie.out = x - blended + neutral
+
+    result = ie.clip
+
+    if blur:
+        # diff = core.std.MakeDiff(clip, result)
+        soft = remove_grain(result, 12)
+        result = core.std.MergeDiff(clip, soft)
+
+    return result

--- a/vsdeband/filmgrain/generator.py
+++ b/vsdeband/filmgrain/generator.py
@@ -1,0 +1,341 @@
+import math
+from dataclasses import dataclass
+from typing import Self
+
+from vsexprtools import inline_expr
+from vsexprtools.inline.helpers import ClipVar, ComputedVar
+from vsexprtools.inline.manager import InlineExprWrapper
+from vsrgtools import remove_grain
+from vstools import (
+    core,
+    get_neutral_values,
+    get_u,
+    get_v,
+    get_y,
+    join,
+    vs,
+)
+
+from ..noise import GrainFactoryBicubic
+from .config import (
+    FilmGrainConfig,
+    GrainConfig,
+    MergeType,
+)
+
+__all__ = [
+    "FilmGrainProcessor",
+    "GrainLayerFactory"
+]
+
+
+@dataclass
+class Chroma:
+    u: float
+    v: float
+
+    def clamp(self, min_value: float, max_value: float) -> Self:
+        self.u = max(min_value, min(max_value, self.u))
+        self.v = max(min_value, min(max_value, self.v))
+        return self
+
+
+class GrainLayerFactory:
+    @staticmethod
+    def create(
+        clip: vs.VideoNode,
+        config: GrainConfig,
+        seed: int,
+        deterministic: bool = True,
+        identifier: int | None = None,
+    ) -> vs.VideoNode:
+
+        blank = clip.std.BlankClip(keep=True, color=get_neutral_values(clip))
+
+        grain_clip = config.grainer(
+            blank,
+            strength=config.strength,
+            static=False,
+            scale=config.size,
+            temporal=config.temporal_blur,
+            scaler=GrainFactoryBicubic(config.sharpness),
+            seed=(seed if deterministic else -1),
+            neutral_out=True,
+            protect_neutral_chroma=False,
+        )
+
+        return grain_clip
+
+
+class PostFilter:
+    def __init__(self, config: FilmGrainConfig):
+        self.config = config
+
+    def emulsion(self, clip: vs.VideoNode) -> vs.VideoNode:
+        return clip
+
+    def path_to_white(self, clip: vs.VideoNode) -> vs.VideoNode:
+        return clip
+
+
+class Prefilter:
+    def __init__(self, config: FilmGrainConfig):
+        self.config = config
+
+    def spatial(self, clip: vs.VideoNode) -> vs.VideoNode:
+        if self.config.preblur is False:
+            return clip
+
+        try:
+            w = clip.width
+            base_strength = self.config.merge.max_strength_y
+            expr = (base_strength ** 0.318 - 0.61) * (max(w / 1920.0 - 0.46, 0.0) ** 0.4 + 0.2) * self.config.preblur
+
+            if expr > 0.35:
+                return core.tcanny.TCanny(clip, expr, mode=-1)
+
+            blur_amount = math.sqrt(self.config.preblur) / 2.0 * math.sqrt(2.0)
+
+            if blur_amount > 0.35:
+                return core.tcanny.TCanny(clip, blur_amount, mode=-1)
+
+        except Exception:
+            pass
+
+        return clip
+
+    def temporal(self, grain_layer: vs.VideoNode) -> vs.VideoNode:
+
+        if not self.config.temporal_blur:
+            return grain_layer
+
+        if isinstance(self.config.temporal_blur, tuple):
+            tb_amount, _ = self.config.temporal_blur
+        else:
+            tb_amount = float(self.config.temporal_blur)
+
+        temporal = grain_layer.zsmooth.TemporalSoften(1, 255, 0, 255)
+        return core.std.Merge(grain_layer, temporal, weight=tb_amount)
+
+
+class FilmGrainProcessor(Prefilter, PostFilter):
+    def __init__(self, config: FilmGrainConfig):
+        super().__init__(config)
+        self.config = config
+        self.factory = GrainLayerFactory()
+        self.post_filter = PostFilter(config)
+        self.prefilter = Prefilter(config)
+
+    def process(self, clip: vs.VideoNode, debug: bool = False) -> vs.VideoNode:
+
+        if self.config.fast:
+            return self._process_fast(clip, debug)
+
+        th1, th2, th3, th4 = self.config.thresholds.to_scaled(clip)
+
+        scaled = self.config.resolution_policy.apply(
+            clip,
+            self.config.merge,
+            self.config.size,
+            self.config.sharpness,
+            self.config.bump,
+            self.config.strength,
+            self.config.s16mm,
+        )
+
+        strengths, size, sharpness, bump = scaled.strengths, scaled.size, scaled.sharpness, scaled.bump
+        gen_y, gen_c = scaled.gen_strength
+
+        base_gcfg = GrainConfig(
+            strength=(gen_y * 10, gen_c * 10),
+            sharpness=sharpness,
+            size=size,
+            grainer=self.config.grainer,
+            blur=True,
+            bump=bump,
+        )
+
+        grain_layer = self.factory.create(clip, base_gcfg, self.config.seed, self.config.deterministic)
+        grain_layer = remove_grain(grain_layer, 12)
+        grain_layer = self.prefilter.temporal(grain_layer)
+
+        preblur_clip = self.prefilter.spatial(clip)
+
+        with inline_expr([preblur_clip, grain_layer]) as ie:
+            x, grain = ie.vars
+
+            normalized = x / x.LumaMax
+
+            match self.config.merge_type:
+                case MergeType.GAMMA:
+                    xs = x
+                case MergeType.LINEAR:
+                    xs = (normalized ** 2.2) * x.RangeMax
+                case MergeType.LOG:
+                    xs = (normalized ** 0.454545) * x.RangeMax
+
+            if self.config.bump != 0.0:
+                neighbor = ie.op.rel_pix(grain, -1, 1)
+                grain = grain + (neighbor - grain) * self.config.bump
+
+            w_dark, w_mid, w_bright = self.generate_ramp(xs, th1, th2, th3, th4)
+
+            applied = (grain - x.Neutral)
+
+            mult_ramp_y = w_dark * strengths.dark.y + w_mid * strengths.mid.y + w_bright * strengths.bright.y
+
+            if any(weight != 1.0 for weight in (strengths.dark.u, strengths.mid.u, strengths.bright.u)):
+                mult_ramp_u = w_dark * strengths.dark.u + w_mid * strengths.mid.u + w_bright * strengths.bright.u
+                mult_ramp_v = w_dark * strengths.dark.v + w_mid * strengths.mid.v + w_bright * strengths.bright.v
+
+                ie.out.y = x + applied * mult_ramp_y
+                ie.out.u = x + applied * mult_ramp_u
+                ie.out.v = x + applied * mult_ramp_v
+
+            ie.out = x + applied * mult_ramp_y
+
+        result = ie.clip
+
+        if debug:
+            return self._debug(result)
+
+        return result
+
+    def _process_fast(self, clip: vs.VideoNode, debug: bool) -> vs.VideoNode:
+
+        th1, th2, th3, th4 = self.config.thresholds.to_scaled(clip)
+
+        scaled = self.config.resolution_policy.apply(
+            clip,
+            self.config.merge,
+            self.config.size,
+            self.config.sharpness,
+            self.config.bump,
+            self.config.strength,
+            self.config.s16mm,
+        )
+
+        strengths, size, sharpness, bump = scaled.strengths, scaled.size, scaled.sharpness, scaled.bump
+        gen_y, gen_c = scaled.gen_strength
+
+        y_in = get_y(clip)
+        y_pre = self.prefilter.spatial(y_in)
+
+        base_gcfg = GrainConfig(
+            strength=gen_y,
+            sharpness=sharpness,
+            size=size,
+            grainer=self.config.grainer,
+            blur=True,
+            bump=bump,
+        )
+
+        grain_y = self.factory.create(y_in, base_gcfg, self.config.seed, self.config.deterministic)
+        grain_y = remove_grain(grain_y, 12)
+        grain_y = self.prefilter.temporal(grain_y)
+
+        grain_yuv = self.y_to_yyy(clip, grain_y)
+        pre_in = join(y_pre, get_u(clip), get_v(clip), vs.ColorFamily.YUV)
+
+        chroma = Chroma(u=strengths.mid.u, v=strengths.mid.v)
+
+        with inline_expr([pre_in, grain_yuv]) as ie:
+            x, grain = ie.vars
+
+            neutral = x.Neutral
+            normalized = x / x.LumaMax
+
+            match self.config.merge_type:
+                case MergeType.GAMMA:
+                    xs = x
+                case MergeType.LINEAR:
+                    xs = (normalized ** 2.2) * x.RangeMax
+                case MergeType.LOG:
+                    xs = (normalized ** 0.454545) * x.RangeMax
+
+            if self.config.bump != 0.0:
+                neighbor = ie.op.rel_pix(grain, -1, 1)
+                grain = grain + (neighbor - grain) * self.config.bump
+
+            w_dark, w_mid, w_bright = self.generate_ramp(xs, th1, th2, th3, th4)
+
+            mult_ramp_y = w_dark * strengths.dark.y + w_mid * strengths.mid.y + w_bright * strengths.bright.y
+
+            applied = (grain - neutral)
+
+            # Adjust chroma amplitude by generator C/Y ratio
+            uv_factor = 1.0 if gen_y == 0 else (gen_c / gen_y)
+
+            if chroma.v == 1.0 and chroma.u == 1.0 and uv_factor == 1.0:
+                ie.out = x + applied * mult_ramp_y
+            else:
+                ie.out.y = x + applied * mult_ramp_y
+                u_applied = applied * uv_factor
+                v_applied = applied * uv_factor
+                ie.out.u = (x + u_applied) if chroma.u == 1.0 else (x + u_applied * chroma.u)
+                ie.out.v = (x + v_applied) if chroma.v == 1.0 else (x + v_applied * chroma.v)
+
+        result = ie.clip
+
+        if debug:
+            return self._debug(result)
+
+        return result
+
+    def y_to_yyy(self, clip: vs.VideoNode, grain_y: vs.VideoNode) -> vs.VideoNode:
+
+        fmt = clip.format
+        assert fmt is not None
+
+        ssx, ssy = fmt.subsampling_w, fmt.subsampling_h
+
+        u_w = clip.width >> ssx
+        u_h = clip.height >> ssy
+
+        grain_u = grain_y.resize.Point(width=u_w, height=u_h)
+        grain_v = grain_u
+
+        return join(grain_y, grain_u, grain_v, vs.ColorFamily.YUV)
+
+
+    def generate_ramp(
+            self, xs: ClipVar | ComputedVar,
+            th1: float, th2: float, th3: float, th4: float
+        ) -> tuple[ComputedVar, ComputedVar, ComputedVar]:
+
+        ie = InlineExprWrapper
+
+        t1 = (xs - th1) / (th2 - th1)
+        t2 = (xs - th3) / (th4 - th3)
+
+        w_dark = ie.op.tern(xs < th1, 1.0, ie.op.tern(xs < th2, 1.0 - t1, 0.0))
+        w_mid = ie.op.tern(xs < th1, 0.0, ie.op.tern(
+            xs < th2, t1, ie.op.tern(xs < th3, 1.0, ie.op.tern(xs < th4, 1.0 - t2, 0.0))))
+        w_bright = ie.op.tern(xs < th3, 0.0, ie.op.tern(xs < th4, t2, 1.0))
+
+        return w_dark, w_mid, w_bright
+
+    def _debug(
+            self, clip: vs.VideoNode
+        ) -> vs.VideoNode:
+
+        debug_text = "\n".join([
+            f"strength: {self.config.strength}",
+            f"grainer: {self.config.grainer}",
+            f"temporal_blur: {self.config.temporal_blur}",
+            f"preblur: {self.config.preblur}",
+            f"bump: {self.config.bump}",
+            f"deterministic: {self.config.deterministic}",
+            f"thresholds: {self.config.thresholds}",
+            f"resolution_policy: {self.config.resolution_policy}",
+            f"seed: {self.config.seed}",
+            f"grain_size: {self.config.size}",
+            f"grain_sharpness: {self.config.sharpness}",
+            f"dark: {self.config.merge.dark}",
+            f"mid: {self.config.merge.mid}",
+            f"bright: {self.config.merge.bright}",
+            f"merge_type: {self.config.merge_type}",
+            f"fast: {self.config.fast}",
+        ])
+
+        return clip.text.Text(text=debug_text)

--- a/vsdeband/filmgrain/helpers.py
+++ b/vsdeband/filmgrain/helpers.py
@@ -1,0 +1,73 @@
+import inspect
+from dataclasses import dataclass, field, fields
+from typing import Any, Callable, Type
+
+from .config import FilmGrainConfig, replace
+
+
+@dataclass(slots=True)
+class Signature:
+    settings: FilmGrainConfig
+    defaults: dict[str, Any]
+    changed: dict[str, Any] = field(init=False, default_factory=dict)
+
+    @classmethod
+    def generate(
+        cls,
+        fn: Callable[..., Any],
+        settings: FilmGrainConfig,
+    ) -> "Signature":
+
+        sig = inspect.signature(fn)
+
+        settings_keys = set(vars(settings))
+
+        defaults: dict[str, Any] = {
+            name: param.default
+            for name, param in sig.parameters.items()
+            if (param.default is not inspect._empty) and (name in settings_keys)
+        }
+
+        return cls(settings, defaults)
+
+    def __post_init__(self):
+        settings = vars(self.settings)
+
+        self.changed = {
+            k: settings[k]
+            for k, default in self.defaults.items()
+            if (k in settings) and (settings[k] != default)
+        }
+
+class Helper:
+    @staticmethod
+    def settings_from_signature(fn: Callable[..., Any], cls: Type[FilmGrainConfig]) -> FilmGrainConfig:
+        sig = inspect.signature(fn)
+
+        names = {f.name for f in fields(cls)}
+
+        base = {
+            n: p.default
+            for n, p in sig.parameters.items()
+            if (n in names) and (p.default is not inspect._empty)
+        }
+
+        return cls(**base)
+
+
+    @staticmethod
+    def resolve_settings(
+        fn: Callable[..., Any],
+        preset: FilmGrainConfig,
+        **user_args
+    ) -> FilmGrainConfig:
+
+        base = Helper.settings_from_signature(fn, FilmGrainConfig)
+
+        merged = base if preset is None else replace(base, **vars(preset))
+
+        base_keys = set(vars(base))
+
+        final_overrides = {k: v for k, v in user_args.items() if k in base_keys}
+        return replace(merged, **final_overrides)
+

--- a/vsdeband/filmgrain/presets.py
+++ b/vsdeband/filmgrain/presets.py
@@ -1,0 +1,284 @@
+import enum
+
+from ..noise import Grainer
+from .config import FilmGrainConfig, MergeStrengths, PlaneStrength
+
+__all__ = [
+    "FilmGrainPreset",
+]
+
+
+class FilmGrainPreset(enum.Enum):
+
+    EIGHT_MM = FilmGrainConfig(
+        strength=(7.0, 0.6),
+        size=2.0,
+        sharpness=60,
+    )
+    SIXTEEN_MM = FilmGrainConfig(
+        merge=MergeStrengths(
+            dark=PlaneStrength(5.5, 5.5, 5.5),
+            mid=PlaneStrength(4.5, 4.5, 4.5),
+            bright=PlaneStrength(3.5, 3.5, 3.5)
+        ),
+        size=1.7,
+        sharpness=66,
+    )
+    THIRTY_FIVE_MM = FilmGrainConfig(
+        merge=MergeStrengths(
+            dark=PlaneStrength(2.5, 2.5, 2.5),
+            mid=PlaneStrength(2.0, 2.0, 2.0),
+            bright=PlaneStrength(1.5, 1.5, 1.5)
+        ),
+        size=1.0,
+        sharpness=80,
+    )
+    FILMGRAIN = FilmGrainConfig(
+        size=1.5,
+        sharpness=90,
+    )
+    GRAINFACTORY = FilmGrainConfig(
+        merge=MergeStrengths(
+            dark=PlaneStrength(1.0, 1.0, 1.0),
+            mid=PlaneStrength(0.9, 0.9, 0.9),
+            bright=PlaneStrength(0.8, 0.8, 0.8)
+        ),
+        size=1.0,
+        sharpness=50,
+    )
+    DIGITAL = FilmGrainConfig(
+        strength=(1.2, 0.5),
+        merge=MergeStrengths(
+            dark=PlaneStrength(1.0, 0.1, 0.1),
+            mid=PlaneStrength(1.0, 0.1, 0.1),
+            bright=PlaneStrength(1.0, 0.1, 0.1)
+        ),
+        size=1.0,
+        sharpness=100,
+    )
+    VHS = FilmGrainConfig(
+        merge=MergeStrengths(
+            dark=PlaneStrength(4.0, 3.5, 3.0),
+            mid=PlaneStrength(3.5, 3.0, 2.5),
+            bright=PlaneStrength(3.0, 2.5, 2.0)
+        ),
+        size=1.8,
+        sharpness=40,
+        temporal_blur=(0.3, 0),
+        grainer=Grainer.GAUSS(hcorr=0.5)
+    )
+
+    EXR_5245_50D = FilmGrainConfig(
+        strength=(0.1, 0.5),
+        size=0.8,
+        sharpness=80,
+    )
+    EXR_5248_100T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.8,
+        sharpness=90,
+    )
+    EXR_5293_200T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    EXR_5298_500T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+
+    VISION_5274_200T = FilmGrainConfig(
+        strength=(0.4, 0.5),
+        size=0.4,
+        sharpness=100,
+    )
+    VISION_5246_250D = FilmGrainConfig(
+        strength=(0.9, 0.5),
+
+        size=0.2,
+        sharpness=100,
+    )
+    VISION_5277_320T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    VISION_5279_500T = FilmGrainConfig(
+        strength=(1.4, 0.5),
+        size=1.9,
+        sharpness=100,
+    )
+
+    VISION2_5201_50D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    VISION2_5212_100T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    VISION2_5217_200T = FilmGrainConfig(
+        strength=(0.2, 0.5),
+
+        size=1.4,
+        sharpness=90,
+    )
+    VISION2_5218_500T = FilmGrainConfig(
+        strength=(0.1, 0.5),
+
+        size=1.3,
+        sharpness=100,
+    )
+    VISION3_5203_50D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    VISION3_5213_200T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    VISION3_5207_250D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    VISION3_5219_500T = FilmGrainConfig(
+        strength=(0.1, 0.5),
+
+        size=0.5,
+        sharpness=100,
+    )
+
+    FX_214_480D = FilmGrainConfig(
+        strength=(0.3, 0.5),
+        size=0.8,
+        sharpness=80,
+    )
+
+    FUJI_8510_64T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+        size=1.0,
+        sharpness=100,
+    )
+    FUJI_8520_64D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    FUJI_8530_125T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    FUJI_8550_250T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    FUJI_8560_250D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    FUJI_8570_500T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+
+    SUPER_F_8522_64D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    SUPER_F_8532_125T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    SUPER_F_8552_250T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    SUPER_F_8562_250D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    SUPER_F_8582_400T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    SUPER_F_8572_500T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+
+    ETERNA_V_8543_160T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    ETERNA_8563_250D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    ETERNA_8583_400T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    ETERNA_8573_500T = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+    REALA_8592_500D = FilmGrainConfig(
+        strength=(1.0, 0.5),
+
+        size=1.0,
+        sharpness=100,
+    )
+
+    def to_config(self) -> FilmGrainConfig:
+        return self.value
+
+    def to_dict(self) -> dict:
+        return {
+            k: v.default
+            for k, v in vars(self.value).items()
+        }


### PR DESCRIPTION
I don't have time to finish these

Grainfactory is luma only in the original havsfunc code and just shuffles back

film_grain should make GrainFactory redundant whilst being faster, but at the cost of losing the ability to fine tune grain for each threshold

bump can probably be implemented into the expr for better performance