### PR TITLE
vstools: fix get_file() extension handling

### DIFF
--- a/tests/vstools/functions/test_file.py
+++ b/tests/vstools/functions/test_file.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import PurePath
+
+import pytest
+
+from vstools import PackageStorage
+
+
+@pytest.fixture(scope="session")
+def storage(request: pytest.FixtureRequest) -> Iterator[PackageStorage]:
+    storage = PackageStorage(cwd=PurePath(__file__).parent)
+    yield storage
+    storage.folder.parent.rmdirs()
+
+
+def test_package_storage_get_file(storage: PackageStorage) -> None:
+    result = storage.get_file("test")
+    assert result.name == "test"
+    assert result.suffix == ""
+
+    result = storage.get_file("test", ext=".txt")
+    assert result.name == "test.txt"
+    assert result.suffix == ".txt"
+
+    result = storage.get_file("test", ext="should-use-my-extension.mkv")
+    assert result.name == "test.mkv"
+    assert result.suffix == ".mkv"
+
+    result = storage.get_file("test", ext=PurePath("should-use-my-extension.mkv"))
+    assert result.name == "test.mkv"
+    assert result.suffix == ".mkv"

--- a/vstools/functions/file.py
+++ b/vstools/functions/file.py
@@ -43,7 +43,7 @@ class PackageStorage:
         filename = SPath(filename)
 
         if ext:
-            filename = filename.with_suffix(SPath(ext).suffix)
+            filename = filename.with_suffix(SPath(ext).suffix or str(ext))
 
         self.ensure_folder()
 


### PR DESCRIPTION
Usually this function is used like so (see the `VideoPackets` or `Keyframes` classes):

```python
storage.get_file("test", ext=".txt")
```

But:

```python
SPath(".txt").suffix == ""
```

So the extension was not being applied. Not sure if this used to work on a previous Python version or what.

If we think I should handle the case where someone tries `ext="txt"` (no `.`), then I can add that.