### PR TITLE
vs_object: remove ABC inheritance

### DIFF
--- a/vsdenoise/mvtools/mvtools.py
+++ b/vsdenoise/mvtools/mvtools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fractions import Fraction
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Literal, MutableMapping, Union, overload
+from typing import Any, Literal, MutableMapping, Union, overload
 
 from vstools import (
     ColorRange,
@@ -398,7 +398,7 @@ class MVTools(vs_object):
         )
 
         if self.vectors.has_vectors:
-            self.vectors.clear()
+            self.vectors = MotionVectors()
 
         self.vectors.tr = tr
 
@@ -1386,7 +1386,7 @@ class MVTools(vs_object):
         if self.mvtools is MVToolsPlugin.FLOAT:
             return vectors.mv_multi[(delta - 1) * 2 + direction - 1 :: vectors.tr * 2]
 
-        return vectors.motion_vectors[direction][delta]
+        return vectors[direction][delta]
 
     @overload
     def get_vectors(
@@ -1470,13 +1470,9 @@ class MVTools(vs_object):
         return (vectors_backward, vectors_forward)
 
     def __vs_del__(self, core_id: int) -> None:
-        if not TYPE_CHECKING:
-            self.clip = None
+        for k, v in self.__dict__.items():
+            if isinstance(v, vs.VideoNode):
+                delattr(self, k)
 
-        for v in self.__dict__.values():
-            if not isinstance(v, MutableMapping):
-                continue
-
-            for k2, v2 in v.items():
-                if isinstance(v2, vs.VideoNode):
-                    v[k2] = None
+            if isinstance(v, MutableMapping):
+                v.clear()

--- a/vsdenoise/mvtools/presets.py
+++ b/vsdenoise/mvtools/presets.py
@@ -271,10 +271,7 @@ class MVToolsPreset(MutableMapping[str, Any], vs_object):
         return self
 
     def __vs_del__(self, core_id: int) -> None:
-        self._dict["search_clip"] = None
-
-        if self._dict["super_args"]:
-            self._dict["super_args"]["pelclip"] = None
+        self.clear()
 
     @classproperty
     @classmethod

--- a/vsdenoise/regress.py
+++ b/vsdenoise/regress.py
@@ -47,7 +47,7 @@ __all__ = [
 ]
 
 
-class _CachedBlurs(vs_object, dict[int, list[tuple[vs.VideoNode, vs.VideoNode]]]):
+class _CachedBlurs(dict[int, list[tuple[vs.VideoNode, vs.VideoNode]]], vs_object):
     def __vs_del__(self, core_id: int) -> None:
         self.clear()
 

--- a/vskernels/abstract/base.py
+++ b/vskernels/abstract/base.py
@@ -5,6 +5,7 @@ This module defines the base abstract interfaces for general scaling operations.
 from __future__ import annotations
 
 from abc import ABC, ABCMeta
+from contextlib import suppress
 from functools import cache, wraps
 from functools import cached_property as functools_cached_property
 from inspect import Signature
@@ -308,9 +309,7 @@ class BaseScaler(vs_object, ABC, metaclass=BaseScalerMeta, abstract=True):
             Create a new instance of the scaler, validating kernel radius if applicable.
             """
             if _check_kernel_radius(cls):
-                obj = super().__new__(cls)
-                obj.kwargs = {}
-                return obj
+                return super().__new__(cls)
 
     def __init__(self, **kwargs: Any) -> None:
         """
@@ -445,7 +444,8 @@ class BaseScaler(vs_object, ABC, metaclass=BaseScalerMeta, abstract=True):
         return frozenset(func for klass in cls.mro() for func in getattr(klass, "_implemented_funcs", ()))
 
     def __vs_del__(self, core_id: int) -> None:
-        self.kwargs.clear()
+        with suppress(AttributeError):
+            self.kwargs.clear()
 
 
 _BaseScalerT = TypeVar("_BaseScalerT", bound=BaseScaler)

--- a/vskernels/util.py
+++ b/vskernels/util.py
@@ -551,11 +551,9 @@ class LinearLight(AbstractContextManager[LinearLightProcessing], vs_object):
         self._exited = True
 
     def __vs_del__(self, core_id: int) -> None:
-        if not TYPE_CHECKING:
-            self.clip = None
-            self.out_fmt = None
-            self._fmt = None
-            self._wclip = None
+        for name in ("clip", "out_fmt", "_fmt", "_wclip"):
+            with suppress(AttributeError):
+                delattr(self, name)
 
 
 def resample_to(

--- a/vsmasktools/hardsub.py
+++ b/vsmasktools/hardsub.py
@@ -59,18 +59,13 @@ __all__ = [
 ]
 
 
-class _BaseCMaskCar(vs_object):
-    clips: list[vs.VideoNode]
-
-    def __vs_del__(self, core_id: int) -> None:
-        self.clips.clear()
-
-
 @dataclass
-class CustomMaskFromClipsAndRanges(GeneralMask, _BaseCMaskCar):
+class CustomMaskFromClipsAndRanges(GeneralMask, vs_object):
     """
     Abstract CustomMaskFromClipsAndRanges interface
     """
+
+    clips: list[vs.VideoNode] = field(init=False)
 
     processing: VSFunctionNoArgs[vs.VideoNode, ConstantFormatVideoNode] = field(
         default=core.lazy.std.BinarizeMask, kw_only=True
@@ -112,6 +107,9 @@ class CustomMaskFromClipsAndRanges(GeneralMask, _BaseCMaskCar):
 
     @abstractmethod
     def frame_ranges(self, clip: vs.VideoNode) -> list[list[tuple[int, int]]]: ...
+
+    def __vs_del__(self, core_id: int) -> None:
+        self.clips.clear()
 
 
 @dataclass

--- a/vsscale/rescale.py
+++ b/vsscale/rescale.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import contextlib
+from abc import ABC
+from contextlib import suppress
 from functools import cached_property, wraps
 from typing import Any, Callable, Sequence, TypeVar
 
@@ -44,7 +45,7 @@ __all__ = [
 _RescaleT = TypeVar("_RescaleT", bound="RescaleBase")
 
 
-class RescaleBase(vs_object):
+class RescaleBase(vs_object, ABC):
     """Base class for Rescale wrapper"""
 
     descale_args: ScalingArgs
@@ -81,7 +82,7 @@ class RescaleBase(vs_object):
 
     def __delattr__(self, name: str) -> None:
         def _delattr(attr: str) -> None:
-            with contextlib.suppress(AttributeError):
+            with suppress(AttributeError):
                 delattr(self, attr)
 
         match name:
@@ -93,7 +94,7 @@ class RescaleBase(vs_object):
             case _:
                 pass
 
-        with contextlib.suppress(AttributeError):
+        with suppress(AttributeError):
             super().__delattr__(name)
 
     @staticmethod

--- a/vssource/formats/dvd/title.py
+++ b/vssource/formats/dvd/title.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass
 from itertools import count
-from typing import TYPE_CHECKING, Callable, Iterator, Sequence, SupportsIndex, overload
+from typing import TYPE_CHECKING, Callable, Sequence, SupportsIndex, overload
 
 from vstools import CustomValueError, T, get_prop, set_output, to_arr, vs, vs_object
 
@@ -63,17 +63,17 @@ class SplitTitle:
         return "\n".join(to_print)
 
 
-class TitleAudios(vs_object, list[vs.AudioNode]):
+class TitleAudios(Sequence[vs.AudioNode], vs_object):
     def __init__(self, title: Title) -> None:
         self.title = title
 
         self.cache = dict[int, vs.AudioNode | None](dict.fromkeys(range(len(self.title._audios))))
 
     @overload
-    def __getitem__(self, idx: SupportsIndex, /) -> vs.AudioNode: ...
+    def __getitem__(self, key: SupportsIndex) -> vs.AudioNode: ...
 
     @overload
-    def __getitem__(self, slicidx: slice, /) -> list[vs.AudioNode]: ...
+    def __getitem__(self, key: slice) -> list[vs.AudioNode]: ...
 
     def __getitem__(self, key: SupportsIndex | slice) -> vs.AudioNode | list[vs.AudioNode]:
         if isinstance(key, slice):
@@ -115,14 +115,8 @@ class TitleAudios(vs_object, list[vs.AudioNode]):
     def __len__(self) -> int:
         return len(self.cache)
 
-    def __iter__(self) -> Iterator[vs.AudioNode]:
-        return (self[i] for i in range(len(self)))
-
     def __vs_del__(self, core_id: int) -> None:
         self.cache.clear()
-
-    if not TYPE_CHECKING:
-        __delitem__ = __setitem__ = None
 
 
 @dataclass

--- a/vstools/functions/funcs.py
+++ b/vstools/functions/funcs.py
@@ -372,4 +372,4 @@ class FunctionUtil(cachedproperty.baseclass, list[int], vs_object):
         return [x if i in self else null for i, x in enumerate(normalize_seq(seq, self.num_planes))]
 
     def __vs_del__(self, core_id: int) -> None:
-        self.__dict__[cachedproperty.cache_key].clear()
+        del self.clip, self.func, self.allowed_cfamilies

--- a/vstools/types/utils.py
+++ b/vstools/types/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, ABCMeta
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -34,7 +33,7 @@ __all__ = [
 ]
 
 
-class vs_object(ABC, metaclass=ABCMeta):  # noqa: N801
+class vs_object:  # noqa: N801
     """
     Special object that follows the lifecycle of the VapourSynth environment/core.
 
@@ -66,8 +65,6 @@ class vs_object(ABC, metaclass=ABCMeta):  # noqa: N801
             register_on_creation(self.__vsdel_register)
 
         return self
-
-    def __post_init__(self) -> None: ...
 
     if TYPE_CHECKING:
 


### PR DESCRIPTION
`vs_object` doesn't use anything from ABC or ABCMeta and is probably just a convenience thing. However that makes inheritance annoying when we have to set custom metaclasses like [here](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jetpack/blob/2df39850fdad361b09fc357108cfc5d2bbfd38c7/vsexprtools/error.py#L23).