### PR TITLE
Scaler.scale: Add resize2 arguments check and more useful error

### DIFF
--- a/vskernels/abstract/base.py
+++ b/vskernels/abstract/base.py
@@ -491,6 +491,20 @@ class Scaler(BaseScaler):
         width, height = self._wh_norm(clip, width, height)
         check_correct_subsampling(clip, width, height)
 
+        resize2_specific_params = ("blur",)
+        is_resize2 = self.scale_function.__name__ == "resize2"
+
+        if not is_resize2 or not any(k in resize2_specific_params for k in {**self.kwargs, **kwargs}):
+            return self.scale_function(
+                clip, **_norm_props_enums(self.get_scale_args(clip, shift, width, height, **kwargs))
+            )
+
+        if missing_args := [arg for arg in resize2_specific_params if not hasattr(self.scale_function, arg)]:
+            raise CustomValueError(
+                f"The scale function is missing required arguments: {', '.join(missing_args)}. "
+                "Please update your scale function to support these arguments."
+            )
+
         return self.scale_function(clip, **_norm_props_enums(self.get_scale_args(clip, shift, width, height, **kwargs)))
 
     def supersample(


### PR DESCRIPTION
I'm not certain about approaching it this way, but I think we should throw a more useful error so people know what to do if they run into an issue like what happened [here](https://discord.com/channels/1168547111139283026/1227687943821594727/1411654617988599910).

Ideally, we should figure out a better way to do this though, so hopefully this can help start that.