### PR TITLE
EdgeDetect: greatly increase mask generation speed 

### DIFF
--- a/vsmasktools/edge/_abstract.py
+++ b/vsmasktools/edge/_abstract.py
@@ -234,7 +234,7 @@ class EdgeDetect(ABC):
         elif hthr < peak:
             mask = norm_expr(mask, f"x {hthr} > {ExprToken.RangeMax} x ?", planes, func=self.__class__)
 
-        if clamp is True:
+        if clamp is True and mask.format.sample_type == vs.FLOAT:
             clamp = (get_lowest_value(mask, range_in=ColorRange.FULL), get_peak_value(mask, range_in=ColorRange.FULL))
 
         if isinstance(clamp, list):


### PR DESCRIPTION
Instead of creating new clips for each matrix defined by the class, we pass the expressions directly to the `_merge_edge` and `_merge_ridge` methods, effectively reducing the number of created clips.