### PR TITLE
vssource: make cache files unique

### DIFF
--- a/vssource/indexers/base.py
+++ b/vssource/indexers/base.py
@@ -106,19 +106,6 @@ class Indexer(ABC):
         self.force = force
         self.indexer_kwargs = kwargs
 
-    def file_corrupted(self, index_path: SPathLike) -> None:
-        err_msg = f'Index file "{index_path}" is corrupted! Delete it and retry.'
-        index_path = SPath(index_path).absolute()
-
-        if self.force:
-            try:
-                index_path.unlink()
-                log.warning("%s: Corrupted index file deleted: %r", str(self.__class__), index_path)
-            except OSError:
-                raise CustomRuntimeError(err_msg, self.__class__)
-        else:
-            raise CustomRuntimeError(err_msg, self.__class__)
-
     @classmethod
     def from_param(
         cls, indexer: str | type[Self] | Self | None = None, /, func_except: FuncExcept | None = None
@@ -263,7 +250,7 @@ class CacheIndexer(Indexer):
     def get_cache_path(source_path: SPathLike, ext: str | None = None) -> SPath:
         from hashlib import blake2s
 
-        source_file = SPath(source_path).absolute()
+        source_file = SPath(source_path).resolve()
         hashed_path = blake2s(source_file.to_str().encode("utf-8"), digest_size=4).hexdigest()
         cache_filename = f"{source_file.name}_{hashed_path}"
 
@@ -380,6 +367,15 @@ class ExternalIndexer(Indexer):
 
     def get_idx_file_path(self, path: SPath) -> SPath:
         return path.with_suffix(f".{self.ext}")
+
+    def file_corrupted(self, index_path: SPath) -> None:
+        if self.force:
+            try:
+                index_path.unlink()
+            except OSError:
+                raise CustomRuntimeError("Index file corrupted, tried to delete it and failed.", self.__class__)
+        else:
+            raise CustomRuntimeError("Index file corrupted! Delete it and retry.", self.__class__)
 
     def index(
         self,

--- a/vssource/indexers/base.py
+++ b/vssource/indexers/base.py
@@ -6,6 +6,7 @@ from functools import cache
 from logging import getLogger
 from os import name as os_name
 from typing import Any, ClassVar, Literal, Protocol, Self
+from hashlib import blake2s
 
 from jetpytools import (
     MISSING,
@@ -247,17 +248,21 @@ class CacheIndexer(Indexer):
     _ext: ClassVar[str | None]
 
     @staticmethod
-    def get_cache_path(file_name: SPathLike, ext: str | None = None) -> SPath:
+    def get_cache_path(source_path: SPathLike, ext: str | None = None) -> SPath:
         storage = _get_indexer_cache_storage()
 
-        return storage.get_file(file_name, ext=ext)
+        source_file = SPath(source_path).absolute()
+        hashed_path = blake2s(source_file.to_str().encode("utf-8"), digest_size=6).hexdigest()
+        cache_filename = f"{source_file.name}_{hashed_path}"
+
+        return storage.get_file(cache_filename, ext=ext)
 
     @classmethod
     def source_func(cls, path: SPathLike, **kwargs: Any) -> vs.VideoNode:
         path = SPath(path)
 
         if cls._cache_arg_name not in kwargs:
-            kwargs[cls._cache_arg_name] = cls.get_cache_path(path.name, cls._ext)
+            kwargs[cls._cache_arg_name] = cls.get_cache_path(path, cls._ext)
 
         return super().source_func(path, **kwargs)
 

--- a/vssource/indexers/base.py
+++ b/vssource/indexers/base.py
@@ -6,7 +6,6 @@ from functools import cache
 from logging import getLogger
 from os import name as os_name
 from typing import Any, ClassVar, Literal, Protocol, Self
-from hashlib import blake2s
 
 from jetpytools import (
     MISSING,
@@ -106,6 +105,19 @@ class Indexer(ABC):
 
         self.force = force
         self.indexer_kwargs = kwargs
+
+    def file_corrupted(self, index_path: SPathLike) -> None:
+        err_msg = f'Index file "{index_path}" is corrupted! Delete it and retry.'
+        index_path = SPath(index_path).absolute()
+
+        if self.force:
+            try:
+                index_path.unlink()
+                log.warning("%s: Corrupted index file deleted: %r", str(self.__class__), index_path)
+            except OSError:
+                raise CustomRuntimeError(err_msg, self.__class__)
+        else:
+            raise CustomRuntimeError(err_msg, self.__class__)
 
     @classmethod
     def from_param(
@@ -249,13 +261,14 @@ class CacheIndexer(Indexer):
 
     @staticmethod
     def get_cache_path(source_path: SPathLike, ext: str | None = None) -> SPath:
-        storage = _get_indexer_cache_storage()
+        from hashlib import blake2s
 
         source_file = SPath(source_path).absolute()
-        hashed_path = blake2s(source_file.to_str().encode("utf-8"), digest_size=6).hexdigest()
-        cache_filename = f"{source_file.name}_{hashed_path}"
+        hashed_path = blake2s(source_file.to_str().encode("utf-8"), digest_size=4).hexdigest()
+        cache_filename = f"{source_file.name}_{hashed_path}.{ext.lstrip('.')}"
 
-        return storage.get_file(cache_filename, ext=ext)
+        storage = _get_indexer_cache_storage()
+        return storage.get_file(cache_filename)
 
     @classmethod
     def source_func(cls, path: SPathLike, **kwargs: Any) -> vs.VideoNode:
@@ -364,15 +377,6 @@ class ExternalIndexer(Indexer):
 
     def get_idx_file_path(self, path: SPath) -> SPath:
         return path.with_suffix(f".{self.ext}")
-
-    def file_corrupted(self, index_path: SPath) -> None:
-        if self.force:
-            try:
-                index_path.unlink()
-            except OSError:
-                raise CustomRuntimeError("Index file corrupted, tried to delete it and failed.", self.__class__)
-        else:
-            raise CustomRuntimeError("Index file corrupted! Delete it and retry.", self.__class__)
 
     def index(
         self,

--- a/vssource/indexers/base.py
+++ b/vssource/indexers/base.py
@@ -265,7 +265,10 @@ class CacheIndexer(Indexer):
 
         source_file = SPath(source_path).absolute()
         hashed_path = blake2s(source_file.to_str().encode("utf-8"), digest_size=4).hexdigest()
-        cache_filename = f"{source_file.name}_{hashed_path}.{ext.lstrip('.')}"
+        cache_filename = f"{source_file.name}_{hashed_path}"
+
+        if ext:
+            cache_filename = f"{cache_filename}.{ext.lstrip('.')}"
 
         storage = _get_indexer_cache_storage()
         return storage.get_file(cache_filename)

--- a/vssource/indexers/misc.py
+++ b/vssource/indexers/misc.py
@@ -126,6 +126,16 @@ class FFMS2(CacheIndexer):
     _cache_arg_name = "cachefile"
     _ext = ".ffindex"
 
+    def source_func(self, path: SPathLike, **kwargs: Any) -> vs.VideoNode:
+        try:
+            return super().source_func(path, **kwargs)
+        except Exception as e:
+            if "The index does not match the source file" in str(e):
+                cache_path = kwargs.get(self._cache_arg_name) or self.get_cache_path(path, self._ext)
+                self.file_corrupted(cache_path)
+                return super().source_func(path, **kwargs)
+            raise
+
 
 class ZipSource(Indexer):
     """

--- a/vssource/indexers/misc.py
+++ b/vssource/indexers/misc.py
@@ -126,13 +126,14 @@ class FFMS2(CacheIndexer):
     _cache_arg_name = "cachefile"
     _ext = ".ffindex"
 
-    def source_func(self, path: SPathLike, **kwargs: Any) -> vs.VideoNode:
+    @classmethod
+    def source_func(cls, path: SPathLike, **kwargs: Any) -> vs.VideoNode:
         try:
             return super().source_func(path, **kwargs)
         except Exception as e:
             if "The index does not match the source file" in str(e):
-                cache_path = kwargs.get(self._cache_arg_name) or self.get_cache_path(path, self._ext)
-                self.file_corrupted(cache_path)
+                cache_path = kwargs.get(cls._cache_arg_name) or cls.get_cache_path(path, cls._ext)
+                cls().file_corrupted(cache_path)
                 return super().source_func(path, **kwargs)
             raise
 

--- a/vssource/indexers/misc.py
+++ b/vssource/indexers/misc.py
@@ -126,17 +126,6 @@ class FFMS2(CacheIndexer):
     _cache_arg_name = "cachefile"
     _ext = ".ffindex"
 
-    @classmethod
-    def source_func(cls, path: SPathLike, **kwargs: Any) -> vs.VideoNode:
-        try:
-            return super().source_func(path, **kwargs)
-        except Exception as e:
-            if "The index does not match the source file" in str(e):
-                cache_path = kwargs.get(cls._cache_arg_name) or cls.get_cache_path(path, cls._ext)
-                cls().file_corrupted(cache_path)
-                return super().source_func(path, **kwargs)
-            raise
-
 
 class ZipSource(Indexer):
     """


### PR DESCRIPTION
This PR concerns index cache file logic in vssource.

### Previous Behaviour

If you used vssource's FFMS2 wrapper, the cache filename was the source filename with its extension replaced by `.ffindex`. This meant two source files with the same name but different extensions would overwrite each other's index files. 

The same issue applied to two files with identical names but that were in different directories. This case also affected BestSource, as it included the source file extension but no information about the file path.

Eg. the source files `folder1/video.mkv` and `folder2/video.mp4` would both be cached as `video.ffindex`.

FFMS2 had an additional issue. If you indexed a source file, then changed that source file and indexed again, instead of FFMS2 automatically reindexing and replacing the cache file it would give the error `The index does not match the source file`. This was annoying as you would have to pinpoint the exact cache file that was problematic and delete it. It also didn't match the behaviour of other indexers such as D2VWitch, which would automatically regenerate the index if passed `force=True`.

### New Behaviour

Cache filenames now include a short hash derived from the absolute source path in addition to the source filename, preventing collisions between files with identical names located in different directories. This change applies to both FFMS2 and BestSource (all `CacheIndexer`s).

Eg. `folder1/video.mkv` -> `video.mkv_904c54a1.ffindex`
`folder2/video.mp4` -> `video.mp4_71d3005e.ffindex`.

As for the second issue, if `force=True`, the FFMS2 wrapper now identifies the aforementioned error, deletes the stale index, logs a warning, and calls FFMS2 again. Otherwise it raises an error and tells the user to manually delete the file.

---

Please take a look at the implementation and let me know if I missed or broke anything.

One small note is that I moved the `file_corrupted()` method from `ExternalIndexer` to `Indexer` so FFMS2 could also access it.