### PR TITLE
get_nvidia_version: Work around deprecation warning

### DIFF
--- a/vstools/utils/gpu.py
+++ b/vstools/utils/gpu.py
@@ -2,7 +2,7 @@ __all__ = ["get_nvidia_version", "is_gpu_available"]
 
 
 def _str_to_ver(string: str) -> tuple[int, int]:
-    return tuple(int(x) for x in string.strip().split(".", 2))  # type: ignore
+    return tuple(int(x) for x in string.split(" ", 1)[0].split(".", 2))  # type: ignore
 
 
 def get_nvidia_version() -> tuple[int, int] | None:
@@ -17,7 +17,7 @@ def get_nvidia_version() -> tuple[int, int] | None:
         pass
     else:
         if not smi.returncode:
-            return _str_to_ver(smi.stdout.splitlines()[5].decode().split(":")[-1])
+            return _str_to_ver(smi.stdout.splitlines()[5].decode().split(":")[-1].strip())
 
     return None
 


### PR DESCRIPTION
This adds a workaround for the issue reported in #295, while remaining backwards compatible (assuming nvidia doesn't muck up more stuff, but we can add more robust parsing then).

Example provided in the issue:

```py
test = b"""

==============NVSMI LOG==============

Timestamp                                              : Fri May 29 15:16:01 2026
Driver Version                                         : 610.47 [Deprecated; will be removed in CUDA 14.0. Use KMD Version instead]
CUDA Version                                           : 13.3 [Deprecated; will be removed in CUDA 14.0. Use CUDA UMD Version instead]
KMD Version                                            : 610.47
CUDA UMD Version                                       : 13.3

Attached GPUs                                          : 1
"""

def _str_to_ver(string: str) -> tuple[int, int]:
    return tuple(int(x) for x in string.split(" ", 1)[0].split(".", 2))  # type: ignore

print(_str_to_ver(test.splitlines()[5].decode().split(":")[-1].strip()))
```

```shell
✘ light@Tio ~/Documents/GitHub/vs-jetpack  nvidia-smi-cuda-deprecated uv run test.py
(610, 47)
```

Example from my Windows encoding system, which does not have up-to-date drivers:

```py
test = b"""

==============NVSMI LOG==============

Timestamp                                              : Fri May 29 06:30:37 2026
Driver Version                                         : 591.86
CUDA Version                                           : 13.1

Attached GPUs                                          : 1
"""

def _str_to_ver(string: str) -> tuple[int, int]:
    return tuple(int(x) for x in string.split(" ", 1)[0].split(".", 2))  # type: ignore

print(_str_to_ver(test.splitlines()[5].decode().split(":")[-1].strip()))
```

```shell
light@Tio ~/Documents/GitHub/vs-jetpack  nvidia-smi-cuda-deprecated uv run test.py
(591, 86)
```


Closes #295.