### PR TITLE
stack_planes: handle fp16 upconversion

### DIFF
--- a/tests/vstools/functions/test_utils.py
+++ b/tests/vstools/functions/test_utils.py
@@ -103,7 +103,12 @@ class TestUtils(TestCase):
         self.assertEqual(result.format.name, "Gray8")
 
 
-formats = [fmt for fmt in vs.PresetVideoFormat if fmt]
+# Remove 32-bit integer formats since resize doesn't support the conversion to it.
+formats = [
+    fmt
+    for fmt in vs.PresetVideoFormat
+    if fmt and ((f := vs.core.get_video_format(fmt)) and f.bits_per_sample != 32 and f.sample_type == vs.INTEGER)
+]
 
 
 @pytest.mark.parametrize(

--- a/vstools/functions/utils.py
+++ b/vstools/functions/utils.py
@@ -807,8 +807,12 @@ def stack_planes(
     if clip.format.color_family is vs.GRAY:
         return clip
 
-    if clip.format.sample_type is vs.FLOAT:
-        clip = depth(clip, 32)
+    # std.PlaneStats and text.Text don't support fp16.
+    # Upconversion from fp16 to fp32.
+    if clip.format.sample_type is vs.FLOAT and (isinstance(offset_chroma, (str, float)) or write_plane_name):
+        clip, bits = expect_bits(clip, 32)
+    else:
+        bits = clip.format.bits_per_sample
 
     if clip.format.color_family is vs.YUV:
         if clip.format.sample_type is vs.FLOAT and shift_float_chroma:
@@ -858,12 +862,10 @@ def stack_planes(
     if mode == "v":
         org = [org]
 
-    stacked = stack_clips(org)
+    # If the source clip was fp16, this will be converted back to fp16 here.
+    stacked = depth(stack_clips(org), bits)
 
-    if clip.format.color_family == vs.RGB:
-        return core.std.RemoveFrameProps(stacked, Matrix.prop_key)
-
-    return stacked
+    return core.std.RemoveFrameProps(stacked, Matrix.prop_key) if clip.format.color_family == vs.RGB else stacked
 
 
 @overload


### PR DESCRIPTION
- Add implicit conversion between fp16 <-> fp32
- Fix the issue unconditionally returning fp32 when the input clip was fp16