### PR TITLE
Fix fine_dehalo masks building for float input

### DIFF
--- a/vsdehalo/mask.py
+++ b/vsdehalo/mask.py
@@ -208,9 +208,8 @@ class FineDehalo[**P, R]:
 
             # At this point, because the mask was made of a shades of grey, we may
             # end up with large areas of dark grey after shrinking. To avoid this,
-            # we amplify and saturate the mask here (actually we could even
-            # binarize it).
-            shrink = norm_expr(shrink, "x 4 *", planes, func=func)
+            # we binarize the mask
+            shrink = Morpho.binarize_mask(shrink, 0.25, planes=planes)
             shrink = Morpho.inpand(shrink, rx, ry, XxpandMode.ELLIPSE, planes=planes, func=func)
 
 			# In float space is possible that the mask values went outside the 0-1 range,

--- a/vsdehalo/mask.py
+++ b/vsdehalo/mask.py
@@ -213,11 +213,25 @@ class FineDehalo[**P, R]:
             shrink = norm_expr(shrink, "x 4 *", planes, func=func)
             shrink = Morpho.inpand(shrink, rx, ry, XxpandMode.ELLIPSE, planes=planes, func=func)
 
+			# In float space is possible that the mask values went outside the 0-1 range,
+            # the blur executed afterwards will not work as expected if we allow those values
+            # because we could have, near edges, extreme positive and negative values which
+			# will not "smooth" properly
+            shrink = norm_expr(shrink, "x 0 mask_max clip", planes, func=func)
+
             # This mask is almost binary, which will produce distinct
             # discontinuities once applied. Then we have to smooth it.
             shrink = box_blur(shrink, passes=2, planes=planes)
 
             # Final mask building #
+
+            # Ensure all intermediary masks used to build the main mask are in legal range
+            large  = norm_expr(large,  "x 0 mask_max clip", planes, func=func)
+            strong = norm_expr(strong, "x 0 mask_max clip", planes, func=func)
+
+            # This is not strictly necessary, but lets normalize all other masks for output
+            edges = norm_expr(edges, "x 0 mask_max clip", planes, func=func)
+            light = norm_expr(light, "x 0 mask_max clip", planes, func=func)
 
             # Previous mask may be a bit weak on the pure edge side, so we ensure
             # that the main edges are really excluded. We do not want them to be


### PR DESCRIPTION
For float input the behavior of fine_dehalo could be different then when executed on a 16bits integer clip, I traced it down to the intermediary masks often going outside the 0-1 range and "breaking" some operation, so ensure that the masks used for those operation are in legal range.

To understand where normalization was necessary I've compared the masks, one by one, between a float clip and the same clip dithered down to 16bit (using `clip.fmtc.bitdepth(bits=16, dmode=1, flt=False)`), I decided to not execute the normalization at each step to not lose those extreme values which may contains "information", but i don't know if it's the right approach.
The masks produced when in float is slightly different then on 16bits integer.