### PR TITLE
Remove internal ColorRange usage

### DIFF
--- a/tests/vsexprtools/test_exprop.py
+++ b/tests/vsexprtools/test_exprop.py
@@ -8,9 +8,9 @@ from jetpytools import clamp
 
 from vsexprtools import ExprOp, ExprToken, expr_func, norm_expr
 from vsexprtools.util import _get_akarin_expr_version
-from vstools import ColorRange, core, get_lowest_value, get_peak_value, vs
+from vstools import Range, core, get_lowest_value, get_peak_value, vs
 
-clip_yuv_limited = ColorRange.LIMITED.apply(core.std.BlankClip(width=2, height=2, format=vs.YUV420P8))
+clip_yuv_limited = Range.LIMITED.apply(core.std.BlankClip(width=2, height=2, format=vs.YUV420P8))
 
 
 @pytest.mark.parametrize(
@@ -24,7 +24,7 @@ clip_yuv_limited = ColorRange.LIMITED.apply(core.std.BlankClip(width=2, height=2
         (ExprToken.RangeSize, None, 256),
     ],
 )
-def test_expr_token_get_value_limited(token: ExprToken, range_in: ColorRange | None, expected: float) -> None:
+def test_expr_token_get_value_limited(token: ExprToken, range_in: Range | None, expected: float) -> None:
     assert token.get_value(clip_yuv_limited, None, range_in) == expected
 
 
@@ -36,7 +36,7 @@ def test_expr_token_get_value_limited(token: ExprToken, range_in: ColorRange | N
     ],
 )
 def test_expr_token_get_value_limited_with_chroma(
-    token: ExprToken, chroma: bool, range_in: ColorRange | None, expected: float
+    token: ExprToken, chroma: bool, range_in: Range | None, expected: float
 ) -> None:
     assert token.get_value(clip_yuv_limited, chroma, range_in) == expected
 
@@ -301,8 +301,8 @@ def test_expr_op_str_polyval(input_clip: vs.VideoNode, coeffs: Sequence[float], 
             if expr.format.sample_type == vs.INTEGER:
                 clamped = clamp(
                     expected,
-                    get_lowest_value(input_clip, range_in=ColorRange.FULL),
-                    get_peak_value(input_clip, range_in=ColorRange.FULL),
+                    get_lowest_value(input_clip, range_in=Range.FULL),
+                    get_peak_value(input_clip, range_in=Range.FULL),
                 )
                 assert f_expr[i][0, 0] == round(clamped)
             else:

--- a/tests/vsexprtools/test_inline.py
+++ b/tests/vsexprtools/test_inline.py
@@ -8,7 +8,7 @@ import pytest
 from vsdenoise import prefilter_to_full_range
 from vsexprtools import inline_expr, norm_expr
 from vsmasktools import Sobel
-from vstools import ColorRange, ConvMode, core, get_video_format, vs
+from vstools import ConvMode, Range, core, get_video_format, vs
 
 
 def _spawn_random(amount: int, format: int = vs.RGB24, length: int | None = None) -> list[vs.VideoNode]:
@@ -72,14 +72,14 @@ def test_inline_expr_advanced(format: int) -> None:
 
             ie.out.y = weight_mul
 
-            if ColorRange.from_video(clip).is_full or clip.format.sample_type is vs.FLOAT:
+            if Range.from_video(clip).is_full or clip.format.sample_type is vs.FLOAT:
                 ie.out.uv = x
             else:
                 chroma_expanded = ((x - x.Neutral) / (x.PlaneMax - x.PlaneMin) + 0.5) * x.RangeMax
 
                 ie.out.uv = ie.op.round(chroma_expanded)
 
-        return ColorRange.FULL.apply(ie.clip)
+        return Range.FULL.apply(ie.clip)
 
     clip, *_ = _spawn_random(1, format)
 

--- a/tests/vstools/enums/test_color.py
+++ b/tests/vstools/enums/test_color.py
@@ -252,10 +252,7 @@ class TestRange(TestCase):
 
     def test_from_video_property(self) -> None:
         clip = vs.core.std.BlankClip(format=vs.YUV420P8)
-        if vs.__version__ >= (74, 0):
-            clip = vs.core.std.SetFrameProp(clip, "_Range", Range.FULL)
-        else:
-            clip = vs.core.std.SetFrameProp(clip, "_ColorRange", Range.FULL)
+        clip = vs.core.std.SetFrameProp(clip, "_Range", Range.FULL)
         result = Range.from_video(clip)
         self.assertEqual(result, Range.FULL)
 
@@ -274,15 +271,6 @@ class TestRange(TestCase):
         clip = vs.core.std.BlankClip(format=vs.YUV420P8)
         result = Range.from_video(clip)
         self.assertEqual(result, Range.LIMITED)
-
-    def test_value_vs(self) -> None:
-        if vs.__version__ < (74, 0):
-            self.assertEqual(Range.LIMITED.value_vs, 1)
-            self.assertEqual(Range.FULL.value_vs, 0)
-
-    def test_value_zimg(self) -> None:
-        self.assertEqual(Range.LIMITED.value_zimg, 0)
-        self.assertEqual(Range.FULL.value_zimg, 1)
 
     def test_value_is_limited(self) -> None:
         self.assertTrue(Range.LIMITED.is_limited)

--- a/tests/vstools/functions/test_heuristics.py
+++ b/tests/vstools/functions/test_heuristics.py
@@ -1,8 +1,6 @@
 from vstools import core, video_heuristics, vs
 
-clip = core.std.BlankClip(None, 640, 360, vs.YUV420P16).std.SetFrameProps(
-    _Matrix=vs.MATRIX_BT709, _ColorRange=vs.RANGE_FULL
-)
+clip = core.std.BlankClip(None, 640, 360, vs.YUV420P16).std.SetFrameProps(_Matrix=vs.MATRIX_BT709, _Range=vs.RANGE_FULL)
 
 
 def test_video_heuristics_props_none() -> None:

--- a/tests/vstools/utils/test_scale.py
+++ b/tests/vstools/utils/test_scale.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from vstools import ColorRange, scale_value, vs
+from vstools import Range, scale_value, vs
 
 
 class TestScale(TestCase):
@@ -70,27 +70,27 @@ class TestScale(TestCase):
         self.assertEqual(result, 235)
 
     def test_scale_value_to_limited(self) -> None:
-        result = scale_value(0, 8, 8, ColorRange.FULL, ColorRange.LIMITED)
+        result = scale_value(0, 8, 8, Range.FULL, Range.LIMITED)
         self.assertEqual(result, 16)
 
-        result = scale_value(24, 8, 8, ColorRange.FULL, ColorRange.LIMITED)
+        result = scale_value(24, 8, 8, Range.FULL, Range.LIMITED)
         self.assertEqual(result, 37)
 
-        result = scale_value(64, 8, 8, ColorRange.FULL, ColorRange.LIMITED)
+        result = scale_value(64, 8, 8, Range.FULL, Range.LIMITED)
         self.assertEqual(result, 71)
 
-        result = scale_value(255, 8, 8, ColorRange.FULL, ColorRange.LIMITED)
+        result = scale_value(255, 8, 8, Range.FULL, Range.LIMITED)
         self.assertEqual(result, 235)
 
     def test_scale_value_from_limited(self) -> None:
-        result = scale_value(0, 8, 8, ColorRange.LIMITED, ColorRange.FULL)
+        result = scale_value(0, 8, 8, Range.LIMITED, Range.FULL)
         self.assertEqual(result, 0)
 
-        result = scale_value(24, 8, 8, ColorRange.LIMITED, ColorRange.FULL)
+        result = scale_value(24, 8, 8, Range.LIMITED, Range.FULL)
         self.assertEqual(result, 9)
 
-        result = scale_value(64, 8, 8, ColorRange.LIMITED, ColorRange.FULL)
+        result = scale_value(64, 8, 8, Range.LIMITED, Range.FULL)
         self.assertEqual(result, 56)
 
-        result = scale_value(235, 8, 8, ColorRange.LIMITED, ColorRange.FULL)
+        result = scale_value(235, 8, 8, Range.LIMITED, Range.FULL)
         self.assertEqual(result, 255)

--- a/vskernels/abstract/base.py
+++ b/vskernels/abstract/base.py
@@ -59,7 +59,6 @@ from vstools import (
     split,
     vs,
 )
-from vstools.enums.color import _norm_props_enums
 
 from ..exceptions import (
     UnknownDescalerError,
@@ -525,9 +524,6 @@ class Scaler(BaseScaler):
 
         scale_args = self.get_scale_args(clip, shift, width, height, **kwargs)
 
-        if vs.__version__ < (74, 0):
-            scale_args = _norm_props_enums(scale_args)
-
         logger.debug("%s: Passing clip: %r; arguments: %s", self.scale, clip, scale_args)
 
         return self.scale_function(clip, **scale_args)
@@ -636,9 +632,6 @@ class Descaler(BaseScaler):
 
         descale_args = self.get_descale_args(clip, shift, width, height, **kwargs)
 
-        if vs.__version__ < (74, 0):
-            descale_args = _norm_props_enums(descale_args)
-
         logger.debug("%s: Passing clip: %r; arguments: %s", self.descale, clip, descale_args)
 
         return self.descale_function(clip, **descale_args)
@@ -670,9 +663,6 @@ class Descaler(BaseScaler):
         width, height = self._wh_norm(clip, width, height)
 
         rescale_args = self.get_rescale_args(clip, shift, width, height, **kwargs)
-
-        if vs.__version__ < (74, 0):
-            rescale_args = _norm_props_enums(rescale_args)
 
         logger.debug("%s: Passing clip: %r; arguments: %s", self.rescale, clip, rescale_args)
 
@@ -800,9 +790,6 @@ class Resampler(BaseScaler):
             chromaloc_in,
             **kwargs,
         )
-
-        if vs.__version__ < (74, 0):
-            resample_args = _norm_props_enums(resample_args)
 
         logger.debug("%s: Passing clip: %r; arguments: %s", self.resample, clip, resample_args)
 

--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -651,14 +651,14 @@ class Range(PropEnum):
     Pixel Range ([ITU-T H.265](https://www.itu.int/rec/T-REC-H.265) Equations E-10 through E-20.
     """
 
-    LIMITED = 0 if vs.__version__ >= (74, 0) else 1
+    LIMITED = 0
     """
     Studio (TV) legal range, 16-235 in 8 bits.
 
     This is primarily used with YUV integer formats.
     """
 
-    FULL = 1 if vs.__version__ >= (74, 0) else 0
+    FULL = 1
     """
     Full (PC) dynamic range, 0-255 in 8 bits.
 
@@ -713,7 +713,7 @@ class Range(PropEnum):
         """
         The key used in props to store the enum.
         """
-        return "_Range" if vs.__version__ >= (74, 0) else "_ColorRange"
+        return "_Range"
 
     @classmethod
     def from_res(cls, frame: vs.VideoNode | vs.VideoFrame) -> Range:

--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -769,7 +769,3 @@ type RangeLike = int | vs.Range | Range | HoldsPropValue
 
 ColorRangeLike = RangeLike  # deprecated
 """Deprecated alias"""
-
-
-def _norm_props_enums(kwargs: dict[str, Any]) -> dict[str, Any]:
-    return {key: (value.value_zimg if isinstance(value, Range) else value) for key, value in kwargs.items()}

--- a/vstools/vs_proxy/proxy.py
+++ b/vstools/vs_proxy/proxy.py
@@ -117,6 +117,7 @@ from vapoursynth import (
     ChromaLocation,
     ColorFamily,
     ColorPrimaries,
+    ColorRange,
     Core,
     CoreCreationFlags,
     Environment,
@@ -136,6 +137,7 @@ from vapoursynth import (
     MediaType,
     MessageType,
     Plugin,
+    Range,
     RawFrame,
     RawNode,
     SampleType,
@@ -161,13 +163,6 @@ from vapoursynth import (
     register_policy,
     unregister_on_destroy,
 )
-
-if __version__ >= (74, 0):
-    from vapoursynth import Range
-else:
-    from vapoursynth import ColorRange
-    from vapoursynth import ColorRange as Range
-
 from vapoursynth import __file__ as vs_file
 from vapoursynth import __pyx_capi__ as pyx_capi  # type: ignore[attr-defined]
 from vapoursynth import _construct_parameter as construct_parameter


### PR DESCRIPTION
All internal ColorRange usages have been removed.
`vstools` being a proxy for `vapoursynth`, `ColorRange` import should be kept as long as VapourSynth provides it.

Closes #323