### PR TITLE
Add support for nlm-hip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ amd = [
     "dfttest2[hipfft,hiprtc]>=10",
     "vapoursynth-bm3dhip>=2.16",
     "vapoursynth-mlrt-migx>=15.16 ; platform_system == 'Linux'",
+    "vapoursynth-nlm-hip>=2"
 ]
 full = [
     "vsjetpack[basic]",

--- a/stubs/vapoursynth/__init__.pyi
+++ b/stubs/vapoursynth/__init__.pyi
@@ -1851,6 +1851,10 @@ class VideoNode(RawNode):
     nlm_cuda: Final[_nlm_cuda._VideoNode_bound.Plugin]
     """Non-local means denoise filter implemented in CUDA"""
 # </attribute/VideoNode_bound/nlm_cuda>
+# <attribute/VideoNode_bound/nlm_hip>
+    nlm_hip: Final[_nlm_hip._VideoNode_bound.Plugin]
+    """Non-local means denoise filter implemented in HIP"""
+# </attribute/VideoNode_bound/nlm_hip>
 # <attribute/VideoNode_bound/nlm_ispc>
     nlm_ispc: Final[_nlm_ispc._VideoNode_bound.Plugin]
     """Non-local means denoise filter implemented in ISPC"""
@@ -2153,6 +2157,10 @@ class Core:
     nlm_cuda: Final[_nlm_cuda._Core_bound.Plugin]
     """Non-local means denoise filter implemented in CUDA"""
 # </attribute/Core_bound/nlm_cuda>
+# <attribute/Core_bound/nlm_hip>
+    nlm_hip: Final[_nlm_hip._Core_bound.Plugin]
+    """Non-local means denoise filter implemented in HIP"""
+# </attribute/Core_bound/nlm_hip>
 # <attribute/Core_bound/nlm_ispc>
     nlm_ispc: Final[_nlm_ispc._Core_bound.Plugin]
     """Non-local means denoise filter implemented in ISPC"""
@@ -3099,6 +3107,22 @@ class _nlm_cuda:
             def NLMeans(self, /, d: _IntLike | None = None, a: _IntLike | None = None, s: _IntLike | None = None, h: _FloatLike | None = None, channels: _AnyStr | None = None, wmode: _IntLike | None = None, wref: _FloatLike | None = None, rclip: VideoNode | None = None, device_id: _IntLike | None = None, num_streams: _IntLike | None = None) -> Any: ...
 
 # </implementation/nlm_cuda>
+
+# <implementation/nlm_hip>
+class _nlm_hip:
+    class _Core_bound:
+        class Plugin(_VSPlugin):
+            @_Wrapper.Function
+            def NLMeans(self, /, clip: VideoNode, d: _IntLike | None = None, a: _IntLike | None = None, s: _IntLike | None = None, h: _FloatLike | None = None, channels: _AnyStr | None = None, wmode: _IntLike | None = None, wref: _FloatLike | None = None, rclip: VideoNode | None = None, device_id: _IntLike | None = None, num_streams: _IntLike | None = None) -> VideoNode: ...
+            @_Wrapper.Function
+            def Version(self, /) -> VideoNode: ...
+
+    class _VideoNode_bound:
+        class Plugin(_VSPlugin):
+            @_Wrapper.Function
+            def NLMeans(self, /, d: _IntLike | None = None, a: _IntLike | None = None, s: _IntLike | None = None, h: _FloatLike | None = None, channels: _AnyStr | None = None, wmode: _IntLike | None = None, wref: _FloatLike | None = None, rclip: VideoNode | None = None, device_id: _IntLike | None = None, num_streams: _IntLike | None = None) -> VideoNode: ...
+
+# </implementation/nlm_hip>
 
 # <implementation/nlm_ispc>
 class _nlm_ispc:

--- a/uv.lock
+++ b/uv.lock
@@ -2592,6 +2592,18 @@ wheels = [
 ]
 
 [[package]]
+name = "vapoursynth-nlm-hip"
+version = "2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vapoursynth" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/20/1272e4ea08c49707b56f5cfacd3a8a8003c828472bcbb197c8001a3ddbfc/vapoursynth_nlm_hip-2-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:733c83446144aad82496c3f5a221ac6865634f10d4edf672b98284725f36ae07", size = 15147884, upload-time = "2026-06-15T22:28:54.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/c868326e565701e762058e31f2d8c8fc9520e51c62e893a57b2542334ee4/vapoursynth_nlm_hip-2-py3-none-win_amd64.whl", hash = "sha256:d14da3bb684d51029b02ed7a48f41cd5e6bb9c9117b6b7b2d210318f0f70f1a4", size = 5851374, upload-time = "2026-06-15T22:28:57.001Z" },
+]
+
+[[package]]
 name = "vapoursynth-nlm-ispc"
 version = "3"
 source = { registry = "https://pypi.org/simple" }
@@ -2833,6 +2845,7 @@ amd = [
     { name = "vapoursynth-mlrt-migx", marker = "sys_platform == 'linux'" },
     { name = "vapoursynth-mlrt-ncnn" },
     { name = "vapoursynth-mlrt-ort" },
+    { name = "vapoursynth-nlm-hip" },
 ]
 cl = [
     { name = "vapoursynth-knlmeanscl" },
@@ -3417,6 +3430,7 @@ requires-dist = [
     { name = "vapoursynth-mvtools", marker = "extra == 'denoise'", specifier = ">=26" },
     { name = "vapoursynth-mvtools", marker = "extra == 'full'", specifier = ">=26" },
     { name = "vapoursynth-nlm-cuda", marker = "extra == 'nvidia'", specifier = ">=4" },
+    { name = "vapoursynth-nlm-hip", marker = "extra == 'amd'", specifier = ">=2" },
     { name = "vapoursynth-nlm-ispc", marker = "extra == 'deband'", specifier = ">=3" },
     { name = "vapoursynth-nlm-ispc", marker = "extra == 'dehalo'", specifier = ">=3" },
     { name = "vapoursynth-nlm-ispc", marker = "extra == 'deinterlace'", specifier = ">=3" },

--- a/vsdenoise/nlm.py
+++ b/vsdenoise/nlm.py
@@ -41,7 +41,7 @@ class NLMeans[**P, R]:
         """
         Automatically selects the best available backend.
 
-        Priority: "cuda" -> "accelerator" -> "gpu" -> "cpu" -> "ispc".
+        Priority: "cuda" -> "hip" -> "accelerator" -> "gpu" -> "cpu" -> "ispc".
         """
 
         ACCELERATOR = "accelerator"
@@ -66,7 +66,12 @@ class NLMeans[**P, R]:
 
         CUDA = "cuda"
         """
-        CUDA (GPU-based) implementation.
+        Nvidia CUDA (GPU-based) implementation.
+        """
+
+        HIP = "hip"
+        """
+        AMD HIP (GPU-based) implementation.
         """
 
         def NLMeans(self, clip: vs.VideoNode, *args: Any, **kwargs: Any) -> vs.VideoNode:  # noqa: N802
@@ -88,6 +93,9 @@ class NLMeans[**P, R]:
             if self == NLMeans.Backend.CUDA:
                 return clip.nlm_cuda.NLMeans(*args, **kwargs)
 
+            if self == NLMeans.Backend.HIP:
+                return clip.nlm_hip.NLMeans(*args, **kwargs)
+
             if self in [NLMeans.Backend.ACCELERATOR, NLMeans.Backend.GPU, NLMeans.Backend.CPU]:
                 return clip.knlm.KNLMeansCL(*args, **kwargs | {"device_type": self.value})
 
@@ -98,6 +106,10 @@ class NLMeans[**P, R]:
             if hasattr(core, "nlm_cuda"):
                 logger.debug("%s: Auto selecting 'NLMeans.Backend.CUDA'", NLMeans.Backend.NLMeans)
                 return NLMeans.Backend.CUDA.NLMeans(clip, *args, **kwargs)
+
+            if hasattr(core, "nlm_hip"):
+                logger.debug("%s: Auto selecting 'NLMeans.Backend.HIP'", NLMeans.Backend.NLMeans)
+                return NLMeans.Backend.HIP.NLMeans(clip, *args, **kwargs)
 
             if hasattr(core, "knlm"):
                 logger.debug("%s: Auto selecting KNLMeansCL auto 'device_type'", NLMeans.Backend.NLMeans)


### PR DESCRIPTION
[Simple HIP port of nlm-cuda](https://github.com/TheFeelTrain/vs-nlm-hip/commit/07352044c42e1b5d4a9bab51a5488629e61788b6#diff-ca66b9203b7924ea58e24932daf846404146821f18e7c0951415db3a2de810e7) providing a large improvement over OpenCL.

Tested on Linux and Windows with a 7900XTX. 

```
nl_means(clip, h=0.4, tr=2, backend=nl_means.Backend.GPU, planes=[1,2])
Output 1001 frames in 7.53 seconds (132.85 fps)

nl_means(clip, h=0.4, tr=2, backend=nl_means.Backend.HIP, planes=[1,2])
Output 1001 frames in 5.63 seconds (177.77 fps)

nl_means(clip, h=0.4, tr=2, backend=nl_means.Backend.HIP, planes=[1,2], num_streams=2)
Output 1001 frames in 3.97 seconds (252.33 fps)

nl_means(clip, h=0.4, tr=2, backend=nl_means.Backend.HIP, planes=[1,2], num_streams=3)
Output 1001 frames in 3.07 seconds (326.45 fps)

```