### PR TITLE
Remove explicit code paths for fp16 CPU filters

### DIFF
--- a/vsrgtools/enum.py
+++ b/vsrgtools/enum.py
@@ -80,15 +80,13 @@ class BlurMatrixBase[Nb: float | int](list[Nb]):
 
         expr_kwargs = expr_kwargs or {}
 
-        fp16 = clip[0].format.sample_type == vs.FLOAT and clip[0].format.bits_per_sample == 16
-
         # Spatial mode
         if self.mode.is_spatial:
             if len(clip) > 1:
                 raise CustomValueError("You can't pass multiple clips when using a spatial mode.", func)
 
             # TODO: https://github.com/vapoursynth/vapoursynth/issues/1101
-            if all([not fp16, len(self) <= 25, all(-1023 <= x <= 1023 for x in self), self.mode != ConvMode.SQUARE]):
+            if all([len(self) <= 25, all(-1023 <= x <= 1023 for x in self), self.mode != ConvMode.SQUARE]):
                 return iterate(clip[0], core.std.Convolution, passes, self, bias, divisor, planes, saturate, self.mode)
 
             return iterate(
@@ -103,7 +101,6 @@ class BlurMatrixBase[Nb: float | int](list[Nb]):
         # Temporal mode
         use_std = all(
             [
-                not fp16,
                 len(self) <= 31,
                 all(-1023 <= x <= 1023 for x in self),
                 not bias,

--- a/vsscale/onnx.py
+++ b/vsscale/onnx.py
@@ -14,14 +14,15 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, SupportsFloat
 
 from jetpytools import CustomRuntimeError, CustomValueError, FileNotExistsError, FuncExcept, SPath, SPathLike
 
-from vsexprtools import ExprOp, combine_expr, norm_expr
+from vsexprtools import norm_expr
 from vskernels import Bilinear, Catrom, Kernel, KernelLike, ScalerLike
+from vsmasktools import Morpho
 from vstools import (
-    ConvMode,
     Matrix,
     ProcessVariableResClip,
     check_variable_resolution,
     core,
+    depth,
     get_color_family,
     get_y,
     join,
@@ -706,11 +707,9 @@ class _Waifu2xCunet(BaseWaifu2x):
         if kwargs.pop("no_tint_fix", False):
             return super().postprocess_clip(clip, input_clip, **kwargs)
 
-        maximum_expr = combine_expr(ExprOp.matrix("x", 1, ConvMode.SQUARE, [(0, 0)])[0])
+        clip = depth(clip, 32)
         tint_fix = norm_expr(
-            clip,
-            ["x 0.5 255 / +", maximum_expr, ExprOp.MIN],
-            func="Waifu2x." + self.__class__.__name__,
+            [clip, Morpho.maximum(clip)], "x 0.5 255 / + y min", func="Waifu2x." + self.__class__.__name__
         )
         return super().postprocess_clip(tint_fix, input_clip, **kwargs)
 

--- a/vstools/functions/utils.py
+++ b/vstools/functions/utils.py
@@ -810,13 +810,6 @@ def stack_planes(
     if clip.format.color_family is vs.GRAY:
         return clip
 
-    # std.PlaneStats and text.Text don't support fp16.
-    # Upconversion from fp16 to fp32.
-    if clip.format.sample_type is vs.FLOAT and (isinstance(offset_chroma, (str, float)) or write_plane_name):
-        clip, bits = expect_bits(clip, 32)
-    else:
-        bits = clip.format.bits_per_sample
-
     if clip.format.color_family is vs.YUV:
         if clip.format.sample_type is vs.FLOAT and shift_float_chroma:
             clip = core.std.Expr(clip, ["", "x 0.5 +"])
@@ -865,8 +858,7 @@ def stack_planes(
     if mode == "v":
         org = [org]
 
-    # If the source clip was fp16, this will be converted back to fp16 here.
-    stacked = depth(stack_clips(org), bits)
+    stacked = stack_clips(org)
 
     return core.std.RemoveFrameProps(stacked, Matrix.prop_key) if clip.format.color_family == vs.RGB else stacked
 


### PR DESCRIPTION
The reasoning goes as follows:
- CPU filters are *strictly* slower on fp16 clips than on fp32 clips, even if run through an fp16 -> fp32 -> filter -> fp32 -> fp16 roundtrip.
- As such, explicitly supporting fp16 clips in CPU filters is purely a maintenance burden with no real benefit. Callers that need to process fp16 clips with CPU filters should convert to fp32 and back on the caller side, which is a) more explicit, b) faster, and c) reduces the maintenance burden in vsjetpack.
- GPU filters are different here, since there fp16 can have genuine performance benefits. Here, fp16 should be allowed. To improve maintainability, any CPU-side pre- or postprocessing done to fp16 clips should a) use standard vs-jetpack functions (as opposed to custom exprs) and b) do conversions to fp32 and back if needed, so that the fp16 code paths stay contained in the GPU filter code.