### PR TITLE
MVTools Preset typing clean-up, remove unsupported `tr`

### DIFF
--- a/vsdeinterlace/funcs.py
+++ b/vsdeinterlace/funcs.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from functools import partial
-from typing import Any, Literal, overload
+from typing import Literal, overload
 
 from jetpytools import CustomEnum, CustomStrEnum, CustomValueError
 
@@ -51,7 +51,7 @@ class InterpolateOverlay(CustomEnum):
         clip: vs.VideoNode,
         pattern: int,
         vectors: MotionVectors | None = None,
-        preset: Mapping[str, Any] = ...,
+        preset: MVToolsPreset = ...,
         blksize: int | tuple[int, int] = 8,
         overlap: int | tuple[int, int] = 2,
         refine: int = 1,
@@ -65,7 +65,7 @@ class InterpolateOverlay(CustomEnum):
         clip: vs.VideoNode,
         pattern: int,
         vectors: MotionVectors | None = None,
-        preset: Mapping[str, Any] = ...,
+        preset: MVToolsPreset = ...,
         blksize: int | tuple[int, int] = 8,
         overlap: int | tuple[int, int] = 2,
         refine: int = 1,
@@ -80,7 +80,7 @@ class InterpolateOverlay(CustomEnum):
         clip: vs.VideoNode,
         pattern: int,
         vectors: MotionVectors | None = None,
-        preset: Mapping[str, Any] = ...,
+        preset: MVToolsPreset = ...,
         blksize: int | tuple[int, int] = 8,
         overlap: int | tuple[int, int] = 2,
         refine: int = 1,
@@ -93,7 +93,7 @@ class InterpolateOverlay(CustomEnum):
         clip: vs.VideoNode,
         pattern: int,
         vectors: MotionVectors | None = None,
-        preset: Mapping[str, Any] = MVToolsPreset.HQ_COHERENCE,
+        preset: MVToolsPreset = MVToolsPreset.HQ_COHERENCE,
         blksize: int | tuple[int, int] = 8,
         overlap: int | tuple[int, int] = 2,
         refine: int = 1,

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator, Iterable, Mapping
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager, suppress
 from copy import deepcopy
 from math import factorial
@@ -416,7 +416,7 @@ class QTempGaussMC(VSObject):
         self,
         *,
         force_tr: int = 0,
-        preset: Mapping[str, Any] = MVToolsPreset.HQ_SAD,
+        preset: MVToolsPreset = MVToolsPreset.HQ_SAD,
         blksize: int | tuple[int, int] = 16,
         overlap: int | tuple[int, int] = 2,
         refine: int = 1,

--- a/vsdenoise/mvtools/__init__.py
+++ b/vsdenoise/mvtools/__init__.py
@@ -6,4 +6,5 @@ from .enums import *
 from .motion import *
 from .mvtools import *
 from .presets import *
+from .types import *
 from .utils import *

--- a/vsdenoise/mvtools/mvtools.py
+++ b/vsdenoise/mvtools/mvtools.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from fractions import Fraction
 from itertools import chain
 from typing import Any, Literal, NamedTuple, overload
@@ -34,6 +33,20 @@ from .enums import (
     SharpMode,
 )
 from .motion import MotionVectors
+from .types import (
+    AnalyzeArgs,
+    BlockFpsArgs,
+    CompensateArgs,
+    DegrainArgs,
+    FlowArgs,
+    FlowBlurArgs,
+    FlowFpsArgs,
+    FlowInterpolateArgs,
+    MaskArgs,
+    RecalculateArgs,
+    ScDetectionArgs,
+    SuperArgs,
+)
 from .utils import normalize_thscd, planes_to_mvtools
 
 __all__ = ["MVTools"]
@@ -143,18 +156,18 @@ class MVTools(VSObject):
         chroma: bool | None = None,
         field: FieldLike | None = None,
         *,
-        super_args: Mapping[str, Any] | None = None,
-        analyze_args: Mapping[str, Any] | None = None,
-        recalculate_args: Mapping[str, Any] | None = None,
-        compensate_args: Mapping[str, Any] | None = None,
-        flow_args: Mapping[str, Any] | None = None,
-        degrain_args: Mapping[str, Any] | None = None,
-        flow_interpolate_args: Mapping[str, Any] | None = None,
-        flow_fps_args: Mapping[str, Any] | None = None,
-        block_fps_args: Mapping[str, Any] | None = None,
-        flow_blur_args: Mapping[str, Any] | None = None,
-        mask_args: Mapping[str, Any] | None = None,
-        sc_detection_args: Mapping[str, Any] | None = None,
+        super_args: SuperArgs | None = None,
+        analyze_args: AnalyzeArgs | None = None,
+        recalculate_args: RecalculateArgs | None = None,
+        compensate_args: CompensateArgs | None = None,
+        flow_args: FlowArgs | None = None,
+        degrain_args: DegrainArgs | None = None,
+        flow_interpolate_args: FlowInterpolateArgs | None = None,
+        flow_fps_args: FlowFpsArgs | None = None,
+        block_fps_args: BlockFpsArgs | None = None,
+        flow_blur_args: FlowBlurArgs | None = None,
+        mask_args: MaskArgs | None = None,
+        sc_detection_args: ScDetectionArgs | None = None,
     ) -> None:
         """
         MVTools is a collection of functions for motion estimation and compensation in video.

--- a/vsdenoise/mvtools/presets.py
+++ b/vsdenoise/mvtools/presets.py
@@ -1,153 +1,32 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
-from typing import Any, Self, TypedDict
+from typing import Any, Self
 
 from jetpytools import KwargsNotNone, classproperty
 
 from vstools import VSFunctionNoArgs, VSObjectABC, vs
 
 from ..prefilters import prefilter_to_full_range
-from .enums import FlowMode, MaskMode, MotionMode, PenaltyMode, RFilterMode, SADMode, SearchMode, SharpMode
+from .enums import MotionMode, SADMode
+from .types import (
+    AnalyzeArgs,
+    BlockFpsArgs,
+    CompensateArgs,
+    DegrainArgs,
+    FlowArgs,
+    FlowBlurArgs,
+    FlowFpsArgs,
+    FlowInterpolateArgs,
+    MaskArgs,
+    RecalculateArgs,
+    ScDetectionArgs,
+    SuperArgs,
+)
 
 __all__ = [
-    "AnalyzeArgs",
-    "BlockFpsArgs",
-    "CompensateArgs",
-    "DegrainArgs",
-    "FlowArgs",
-    "FlowBlurArgs",
-    "FlowFpsArgs",
-    "FlowInterpolateArgs",
     "MVToolsPreset",
-    "MaskArgs",
-    "RecalculateArgs",
-    "ScDetectionArgs",
-    "SuperArgs",
 ]
-
-
-class SuperArgs(TypedDict, total=False):
-    levels: int | None
-    sharp: SharpMode | None
-    rfilter: RFilterMode | None
-    pelclip: vs.VideoNode | VSFunctionNoArgs | None
-
-
-class AnalyzeArgs(TypedDict, total=False):
-    blksize: int | None
-    blksizev: int | None
-    levels: int | None
-    search: SearchMode | None
-    searchparam: int | None
-    pelsearch: int | None
-    lambda_: int | None
-    truemotion: MotionMode | None
-    lsad: int | None
-    plevel: PenaltyMode | None
-    global_: bool | None
-    pnew: int | None
-    pzero: int | None
-    pglobal: int | None
-    overlap: int | None
-    overlapv: int | None
-    divide: bool | None
-    badsad: int | None
-    badrange: int | None
-    meander: bool | None
-    trymany: bool | None
-    dct: SADMode | None
-
-
-class RecalculateArgs(TypedDict, total=False):
-    thsad: int | None
-    blksize: int | None
-    blksizev: int | None
-    search: SearchMode | None
-    searchparam: int | None
-    lambda_: int | None
-    truemotion: MotionMode | None
-    pnew: int | None
-    overlap: int | None
-    overlapv: int | None
-    divide: bool | None
-    meander: bool | None
-    dct: SADMode | None
-
-
-class CompensateArgs(TypedDict, total=False):
-    scbehavior: bool | None
-    thsad: int | None
-    time: float | None
-    thscd1: int | None
-    thscd2: int | None
-
-
-class FlowArgs(TypedDict, total=False):
-    time: float | None
-    mode: FlowMode | None
-    thscd1: int | None
-    thscd2: int | None
-
-
-class DegrainArgs(TypedDict, total=False):
-    thsad: int | None
-    thsadc: int | None
-    limit: int | None
-    limitc: int | None
-    thscd1: int | None
-    thscd2: int | None
-    plane: int | None
-
-
-class FlowInterpolateArgs(TypedDict, total=False):
-    time: float | None
-    ml: float | None
-    blend: bool | None
-    thscd1: int | None
-    thscd2: int | None
-
-
-class FlowFpsArgs(TypedDict, total=False):
-    mask: int | None
-    ml: float | None
-    blend: bool | None
-    thscd1: int | None
-    thscd2: int | None
-    num: int
-    den: int
-
-
-class BlockFpsArgs(TypedDict, total=False):
-    mode: int | None
-    ml: float | None
-    blend: bool | None
-    thscd1: int | None
-    thscd2: int | None
-    num: int
-    den: int
-
-
-class FlowBlurArgs(TypedDict, total=False):
-    blur: float | None
-    prec: int | None
-    thscd1: int | None
-    thscd2: int | None
-
-
-class MaskArgs(TypedDict, total=False):
-    ml: float | None
-    gamma: float | None
-    kind: MaskMode | None
-    time: float | None
-    ysc: int | None
-    thscd1: int | None
-    thscd2: int | None
-
-
-class ScDetectionArgs(TypedDict, total=False):
-    thscd1: int | None
-    thscd2: int | None
 
 
 class MVToolsPreset(VSObjectABC, Mapping[str, Any]):

--- a/vsdenoise/mvtools/presets.py
+++ b/vsdenoise/mvtools/presets.py
@@ -152,7 +152,6 @@ class ScDetectionArgs(TypedDict, total=False):
 
 class MVToolsPreset(VSObjectABC, Mapping[str, Any]):
     search_clip: vs.VideoNode | VSFunctionNoArgs
-    tr: int
     pel: int
     pad: int | tuple[int | None, int | None]
     chroma: bool
@@ -173,7 +172,6 @@ class MVToolsPreset(VSObjectABC, Mapping[str, Any]):
         self,
         *,
         search_clip: vs.VideoNode | VSFunctionNoArgs | None = None,
-        tr: int | None = None,
         pel: int | None = None,
         pad: int | tuple[int | None, int | None] | None = None,
         chroma: bool | None = None,
@@ -192,7 +190,6 @@ class MVToolsPreset(VSObjectABC, Mapping[str, Any]):
     ) -> None:
         self._dict = KwargsNotNone(
             search_clip=search_clip,
-            tr=tr,
             pel=pel,
             pad=pad,
             chroma=chroma,

--- a/vsdenoise/mvtools/types.py
+++ b/vsdenoise/mvtools/types.py
@@ -1,0 +1,143 @@
+from typing import TypedDict
+
+from vstools import VSFunctionNoArgs, vs
+
+from .enums import FlowMode, MaskMode, MotionMode, PenaltyMode, RFilterMode, SADMode, SearchMode, SharpMode
+
+__all__ = [
+    "AnalyzeArgs",
+    "BlockFpsArgs",
+    "CompensateArgs",
+    "DegrainArgs",
+    "FlowArgs",
+    "FlowBlurArgs",
+    "FlowFpsArgs",
+    "FlowInterpolateArgs",
+    "MaskArgs",
+    "RecalculateArgs",
+    "ScDetectionArgs",
+    "SuperArgs",
+]
+
+
+class SuperArgs(TypedDict, total=False):
+    levels: int | None
+    sharp: SharpMode | None
+    rfilter: RFilterMode | None
+    pelclip: vs.VideoNode | VSFunctionNoArgs | None
+
+
+class AnalyzeArgs(TypedDict, total=False):
+    blksize: int | None
+    blksizev: int | None
+    levels: int | None
+    search: SearchMode | None
+    searchparam: int | None
+    pelsearch: int | None
+    lambda_: int | None
+    truemotion: MotionMode | None
+    lsad: int | None
+    plevel: PenaltyMode | None
+    global_: bool | None
+    pnew: int | None
+    pzero: int | None
+    pglobal: int | None
+    overlap: int | None
+    overlapv: int | None
+    divide: bool | None
+    badsad: int | None
+    badrange: int | None
+    meander: bool | None
+    trymany: bool | None
+    dct: SADMode | None
+
+
+class RecalculateArgs(TypedDict, total=False):
+    thsad: int | None
+    blksize: int | None
+    blksizev: int | None
+    search: SearchMode | None
+    searchparam: int | None
+    lambda_: int | None
+    truemotion: MotionMode | None
+    pnew: int | None
+    overlap: int | None
+    overlapv: int | None
+    divide: bool | None
+    meander: bool | None
+    dct: SADMode | None
+
+
+class CompensateArgs(TypedDict, total=False):
+    scbehavior: bool | None
+    thsad: int | None
+    time: float | None
+    thscd1: int | None
+    thscd2: int | None
+
+
+class FlowArgs(TypedDict, total=False):
+    time: float | None
+    mode: FlowMode | None
+    thscd1: int | None
+    thscd2: int | None
+
+
+class DegrainArgs(TypedDict, total=False):
+    thsad: int | None
+    thsadc: int | None
+    limit: int | None
+    limitc: int | None
+    thscd1: int | None
+    thscd2: int | None
+    plane: int | None
+
+
+class FlowInterpolateArgs(TypedDict, total=False):
+    time: float | None
+    ml: float | None
+    blend: bool | None
+    thscd1: int | None
+    thscd2: int | None
+
+
+class FlowFpsArgs(TypedDict, total=False):
+    mask: int | None
+    ml: float | None
+    blend: bool | None
+    thscd1: int | None
+    thscd2: int | None
+    num: int
+    den: int
+
+
+class BlockFpsArgs(TypedDict, total=False):
+    mode: int | None
+    ml: float | None
+    blend: bool | None
+    thscd1: int | None
+    thscd2: int | None
+    num: int
+    den: int
+
+
+class FlowBlurArgs(TypedDict, total=False):
+    blur: float | None
+    prec: int | None
+    thscd1: int | None
+    thscd2: int | None
+
+
+class MaskArgs(TypedDict, total=False):
+    ml: float | None
+    gamma: float | None
+    kind: MaskMode | None
+    time: float | None
+    ysc: int | None
+    thscd1: int | None
+    thscd2: int | None
+
+
+class ScDetectionArgs(TypedDict, total=False):
+    thscd1: int | None
+    thscd2: int | None


### PR DESCRIPTION
A handful of updates for MVTools presets, mostly in terms of typing (though it also includes removing something).

I'm not 100% sure if we *really* want to remove `tr` in `MVToolsPreset` vs. figuring out something better in each relevant caller, but right now, it errors on every function I know that uses it because the `MVTools` constructor does not take `tr`.

Concerning typing, I noticed that changing the typing of the `MVTools`' attributes caused mypy to error. I don't know if that needs some changes before merging. I'm also not 100% sure I caught everything.