### PR TITLE
placebo_deband: remove unconditional planes splitting for YUV/RGB clips

### DIFF
--- a/vsdeband/debanders.py
+++ b/vsdeband/debanders.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from vsexprtools import norm_expr
 from vsrgtools import gauss_blur
-from vstools import Planes, core, join, normalize_param_planes, split, vs
+from vstools import Planes, core, normalize_param_planes, vs
 
 __all__ = ["f3k_deband", "mdb_bilateral", "pfdeband", "placebo_deband"]
 
@@ -350,25 +350,20 @@ def placebo_deband(
         return clip.placebo.Deband(plane, iterations, threshold, radius, grain_val, **kwargs)
 
     set_grn = set(ngrain)
+    set_thr = set(thr)
 
-    if set_grn == {0} or clip.format.num_planes == 1:
-        debs = [_placebo(p, t, ngrain[0], [0]) for p, t in zip(split(clip), thr)]
+    if clip.format.num_planes == 1 or (len(set_thr) == 1 and len(set_grn) == 1):
+        return _placebo(clip, thr[0], ngrain[0], range(clip.format.num_planes))
 
-        if len(debs) == 1:
-            return debs[0]
-
-        return join(debs, clip.format.color_family)
-
-    plane_map = {tuple(i for i in range(clip.format.num_planes) if ngrain[i] == x): x for x in set_grn - {0}}
+    plane_map = {tuple(i for i in range(clip.format.num_planes) if ngrain[i] == x): x for x in set_grn}
 
     debanded = clip
-
     for planes, grain_val in plane_map.items():
         if len({thr[p] for p in planes}) == 1:
             debanded = _placebo(debanded, thr[planes[0]], grain_val, planes)
         else:
             for p in planes:
-                debanded = _placebo(debanded, thr[p], grain_val, planes)
+                debanded = _placebo(debanded, thr[p], grain_val, [p])
 
     return debanded
 

--- a/vsdeband/debanders.py
+++ b/vsdeband/debanders.py
@@ -338,6 +338,15 @@ def placebo_deband(
         for p in planes:
             plane |= pow(2, p)
 
+        logger.debug(
+            "placebo.Deband params: plane=%d, iterations=%d, threshold=%f, radius=%f, grain=%f, %s",
+            plane,
+            iterations,
+            threshold,
+            radius,
+            grain_val,
+            kwargs,
+        )
         return clip.placebo.Deband(plane, iterations, threshold, radius, grain_val, **kwargs)
 
     set_grn = set(ngrain)

--- a/vsdeband/debanders.py
+++ b/vsdeband/debanders.py
@@ -308,7 +308,7 @@ def placebo_deband(
     Debanding wrapper around the `placebo.Deband` filter from the VapourSynth `vs-placebo` plugin.
 
     For full plugin documentation, see:
-    <https://github.com/sgt0/vs-placebo?tab=readme-ov-file#deband>
+    <https://github.com/Lypheo/vs-placebo?tab=readme-ov-file#deband>
 
     Args:
         clip: Input clip.


### PR DESCRIPTION
According to my benchmarks, this optimization path isn't needed anymore
(Tested on Win11 9800X3D, RTX 5070Ti)
https://github.com/Lypheo/vs-placebo/issues/4

- Real scenario
```
# 16-bit (705.17 fps)
# 32-bit (439.07 fps)
a.set_output(0)
# 16-bit (615.44 fps)
# 32-bit (415.43 fps)
b.set_output(1)
```
- Blank clip doesn't show any difference