### PR TITLE
morpho: use expr path only on FLOAT clips

### DIFF
--- a/vsmasktools/morpho.py
+++ b/vsmasktools/morpho.py
@@ -453,7 +453,7 @@ class Morpho:
         else:
             r, conv_mode = radius, ConvMode.SQUARE
 
-        if iterations == 1 and conv_mode is not ConvMode.HV:
+        if iterations == 1 and conv_mode is not ConvMode.HV and clip.format.sample_type is vs.FLOAT:
             morpho_func = partial(self._morpho_xx_imum, clip, (r, conv_mode), thr, coords, None, True, func=func)
             return norm_expr(
                 clip,
@@ -591,7 +591,7 @@ class Morpho:
         else:
             r, conv_mode = radius, ConvMode.SQUARE
 
-        if iterations == 1 and conv_mode is not ConvMode.HV:
+        if iterations == 1 and conv_mode is not ConvMode.HV and clip.format.sample_type is vs.FLOAT:
             return norm_expr(
                 clip,
                 "{dilated} {multiply} x -",
@@ -650,7 +650,7 @@ class Morpho:
         else:
             r, conv_mode = radius, ConvMode.SQUARE
 
-        if iterations == 1 and conv_mode is not ConvMode.HV:
+        if iterations == 1 and conv_mode is not ConvMode.HV and clip.format.sample_type is vs.FLOAT:
             return norm_expr(
                 clip,
                 "x {eroded} {multiply} -",


### PR DESCRIPTION
[benchmark_morpho_paths.py](https://github.com/user-attachments/files/29312850/benchmark_morpho_paths.py)

Benchmarking Morpho Expr vs Std paths (Resolution: 1920x1080, Frames: 1000)
BestSource indexed with resize.Point resample

| Format | Operation | Expr Path FPS | Std Path FPS | Ratio (Expr/Std) | Faster? |
| :--- | :--- | :---: | :---: | :---: | :---: |
| GRAY8 | gradient | 645.26 | 748.05 | 0.86x | **Std Path** |                                                                                                                                                                    
| GRAY8 | outer_hat | 640.20 | 741.74 | 0.86x | **Std Path** |
| GRAY8 | inner_hat | 646.29 | 743.38 | 0.87x | **Std Path** |
| GRAY16 | gradient | 612.38 | 680.08 | 0.90x | **Std Path** |                                                                                                                                                                   
| GRAY16 | outer_hat | 642.86 | 708.28 | 0.91x | **Std Path** |
| GRAY16 | inner_hat | 632.31 | 707.99 | 0.89x | **Std Path** |
| GRAYH | gradient | 634.38 | Unsupported | - | **Expr Path Only** |                                                                                                                                                             
| GRAYH | outer_hat | 525.05 | Unsupported | - | **Expr Path Only** |
| GRAYH | inner_hat | 524.75 | Unsupported | - | **Expr Path Only** |
| GRAYS | gradient | 612.38 | 512.97 | 1.19x | **Expr Path** |                                                                                                                                                                   
| GRAYS | outer_hat | 616.66 | 607.03 | 1.02x | Comparable |
| GRAYS | inner_hat | 608.74 | 585.86 | 1.04x | Comparable |
| YUV420P8 | gradient | 588.63 | 727.12 | 0.81x | **Std Path** |                                                                                                                                                                 
| YUV420P8 | outer_hat | 581.72 | 735.58 | 0.79x | **Std Path** |
| YUV420P8 | inner_hat | 589.01 | 732.87 | 0.80x | **Std Path** |
| YUV420P16 | gradient | 561.99 | 630.58 | 0.89x | **Std Path** |                                                                                                                                                                
| YUV420P16 | outer_hat | 564.68 | 680.53 | 0.83x | **Std Path** |
| YUV420P16 | inner_hat | 563.56 | 684.53 | 0.82x | **Std Path** |
| YUV420PH | gradient | 567.27 | Unsupported | - | **Expr Path Only** |                                                                                                                                                          
| YUV420PH | outer_hat | 435.22 | Unsupported | - | **Expr Path Only** |
| YUV420PH | inner_hat | 436.38 | Unsupported | - | **Expr Path Only** |
| YUV420PS | gradient | 540.26 | 384.03 | 1.41x | **Expr Path** |                                                                                                                                                                
| YUV420PS | outer_hat | 548.12 | 463.44 | 1.18x | **Expr Path** |
| YUV420PS | inner_hat | 539.05 | 460.19 | 1.17x | **Expr Path** |

Benchmarking Morpho Expr vs Std paths (Resolution: 1920x1080, Frames: 1000)
BlankClip(keep=True)

| Format | Operation | Expr Path FPS | Std Path FPS | Ratio (Expr/Std) | Faster? |
| :--- | :--- | :---: | :---: | :---: | :---: |
| GRAY8 | gradient | 2067.99 | 6810.39 | 0.30x | **Std Path** |
| GRAY8 | outer_hat | 1995.92 | 12364.81 | 0.16x | **Std Path** |
| GRAY8 | inner_hat | 2046.12 | 12000.96 | 0.17x | **Std Path** |
| GRAY16 | gradient | 1962.34 | 2698.05 | 0.73x | **Std Path** |
| GRAY16 | outer_hat | 2004.68 | 4214.42 | 0.48x | **Std Path** |
| GRAY16 | inner_hat | 2000.80 | 4210.72 | 0.48x | **Std Path** |
| GRAYH | gradient | 2102.27 | Unsupported | - | **Expr Path Only** |
| GRAYH | outer_hat | 1049.89 | Unsupported | - | **Expr Path Only** |
| GRAYH | inner_hat | 1047.03 | Unsupported | - | **Expr Path Only** |
| GRAYS | gradient | 2018.18 | 1096.51 | 1.84x | **Expr Path** |
| GRAYS | outer_hat | 2043.07 | 1723.49 | 1.19x | **Expr Path** |
| GRAYS | inner_hat | 2090.15 | 1739.29 | 1.20x | **Expr Path** |
| YUV420P8 | gradient | 1379.56 | 2977.74 | 0.46x | **Std Path** |
| YUV420P8 | outer_hat | 1343.59 | 4624.04 | 0.29x | **Std Path** |
| YUV420P8 | inner_hat | 1424.85 | 5603.33 | 0.25x | **Std Path** |
| YUV420P16 | gradient | 1299.61 | 1465.09 | 0.89x | **Std Path** |
| YUV420P16 | outer_hat | 1340.93 | 2418.95 | 0.55x | **Std Path** |
| YUV420P16 | inner_hat | 1329.44 | 2458.14 | 0.54x | **Std Path** |
| YUV420PH | gradient | 1404.04 | Unsupported | - | **Expr Path Only** |
| YUV420PH | outer_hat | 699.23 | Unsupported | - | **Expr Path Only** |
| YUV420PH | inner_hat | 708.02 | Unsupported | - | **Expr Path Only** |
| YUV420PS | gradient | 1356.01 | 693.50 | 1.96x | **Expr Path** |
| YUV420PS | outer_hat | 1372.81 | 1106.55 | 1.24x | **Expr Path** |
| YUV420PS | inner_hat | 1398.58 | 1106.49 | 1.26x | **Expr Path** |