### PR TITLE
vstools: add NumPy support to format and scaling utilities

### DIFF
--- a/tests/vstools/utils/test_info.py
+++ b/tests/vstools/utils/test_info.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
-from vstools import get_h, get_w, vs
+import numpy as np
+
+from vstools import get_depth, get_h, get_sample_type, get_w, vs
 
 
 class TestInfo(TestCase):
@@ -17,3 +19,30 @@ class TestInfo(TestCase):
 
         clip = vs.core.std.BlankClip(format=vs.YUV420P8, width=1920, height=1080)
         self.assertEqual(get_h(1920, clip), 1080)
+
+    def test_get_video_format_numpy(self) -> None:
+        # Dtypes
+        self.assertEqual(get_depth(np.uint8), 8)
+        self.assertEqual(get_sample_type(np.uint8), vs.INTEGER)
+
+        self.assertEqual(get_depth(np.dtype("uint16")), 16)
+        self.assertEqual(get_sample_type(np.dtype("uint16")), vs.INTEGER)
+
+        self.assertEqual(get_depth(np.float32), 32)
+        self.assertEqual(get_sample_type(np.float32), vs.FLOAT)
+
+        # Arrays
+        arr_u8 = np.zeros((10, 10), dtype=np.uint8)
+        self.assertEqual(get_depth(arr_u8), 8)
+        self.assertEqual(get_sample_type(arr_u8), vs.INTEGER)
+
+        arr_f32 = np.zeros((10, 10), dtype=np.float32)
+        self.assertEqual(get_depth(arr_f32), 32)
+        self.assertEqual(get_sample_type(arr_f32), vs.FLOAT)
+
+        # String representations
+        self.assertEqual(get_depth("uint8"), 8)
+        self.assertEqual(get_sample_type("uint8"), vs.INTEGER)
+
+        self.assertEqual(get_depth("float32"), 32)
+        self.assertEqual(get_sample_type("float32"), vs.FLOAT)

--- a/tests/vstools/utils/test_info.py
+++ b/tests/vstools/utils/test_info.py
@@ -1,48 +1,51 @@
-from unittest import TestCase
-
 import numpy as np
 
 from vstools import get_depth, get_h, get_sample_type, get_w, vs
 
 
-class TestInfo(TestCase):
-    def test_get_w(self) -> None:
-        self.assertEqual(get_w(1080, 16 / 9), 1920)
-        self.assertEqual(get_w(1080, 4 / 3), 1440)
+def test_get_w() -> None:
+    assert get_w(1080, 16 / 9) == 1920
+    assert get_w(1080, 4 / 3) == 1440
 
-        clip = vs.core.std.BlankClip(format=vs.YUV420P8, width=1920, height=1080)
-        self.assertEqual(get_w(1080, clip), 1920)
+    clip = vs.core.std.BlankClip(format=vs.YUV420P8, width=1920, height=1080)
+    assert get_w(1080, clip) == 1920
 
-    def test_get_h(self) -> None:
-        self.assertEqual(get_h(1920, 16 / 9), 1080)
-        self.assertEqual(get_h(1440, 4 / 3), 1080)
 
-        clip = vs.core.std.BlankClip(format=vs.YUV420P8, width=1920, height=1080)
-        self.assertEqual(get_h(1920, clip), 1080)
+def test_get_h() -> None:
+    assert get_h(1920, 16 / 9) == 1080
+    assert get_h(1440, 4 / 3) == 1080
 
-    def test_get_video_format_numpy(self) -> None:
-        # Dtypes
-        self.assertEqual(get_depth(np.uint8), 8)
-        self.assertEqual(get_sample_type(np.uint8), vs.INTEGER)
+    clip = vs.core.std.BlankClip(format=vs.YUV420P8, width=1920, height=1080)
+    assert get_h(1920, clip) == 1080
 
-        self.assertEqual(get_depth(np.dtype("uint16")), 16)
-        self.assertEqual(get_sample_type(np.dtype("uint16")), vs.INTEGER)
 
-        self.assertEqual(get_depth(np.float32), 32)
-        self.assertEqual(get_sample_type(np.float32), vs.FLOAT)
+def test_get_video_format_numpy_dtypes() -> None:
+    # Dtypes
+    assert get_depth(np.uint8) == 8
+    assert get_sample_type(np.uint8) == vs.INTEGER
 
-        # Arrays
-        arr_u8 = np.zeros((10, 10), dtype=np.uint8)
-        self.assertEqual(get_depth(arr_u8), 8)
-        self.assertEqual(get_sample_type(arr_u8), vs.INTEGER)
+    assert get_depth(np.dtype("uint16")) == 16
+    assert get_sample_type(np.dtype("uint16")) == vs.INTEGER
 
-        arr_f32 = np.zeros((10, 10), dtype=np.float32)
-        self.assertEqual(get_depth(arr_f32), 32)
-        self.assertEqual(get_sample_type(arr_f32), vs.FLOAT)
+    assert get_depth(np.float32) == 32
+    assert get_sample_type(np.float32) == vs.FLOAT
 
-        # String representations
-        self.assertEqual(get_depth("uint8"), 8)
-        self.assertEqual(get_sample_type("uint8"), vs.INTEGER)
 
-        self.assertEqual(get_depth("float32"), 32)
-        self.assertEqual(get_sample_type("float32"), vs.FLOAT)
+def test_get_video_format_numpy_arrays() -> None:
+    # Arrays
+    arr_u8 = np.zeros((10, 10), dtype=np.uint8)
+    assert get_depth(arr_u8) == 8
+    assert get_sample_type(arr_u8) == vs.INTEGER
+
+    arr_f32 = np.zeros((10, 10), dtype=np.float32)
+    assert get_depth(arr_f32) == 32
+    assert get_sample_type(arr_f32) == vs.FLOAT
+
+
+def test_get_video_format_numpy_strings() -> None:
+    # String representations
+    assert get_depth("uint8") == 8
+    assert get_sample_type("uint8") == vs.INTEGER
+
+    assert get_depth("float32") == 32
+    assert get_sample_type("float32") == vs.FLOAT

--- a/tests/vstools/utils/test_scale.py
+++ b/tests/vstools/utils/test_scale.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
-from vstools import Range, scale_value, vs
+import numpy as np
+
+from vstools import Range, scale_delta, scale_mask, scale_value, vs
 
 
 class TestScale(TestCase):
@@ -94,3 +96,28 @@ class TestScale(TestCase):
 
         result = scale_value(235, 8, 8, Range.LIMITED, Range.FULL)
         self.assertEqual(result, 255)
+
+    def test_scale_value_numpy(self) -> None:
+        arr = np.array([0, 24, 64, 255], dtype=np.uint8)
+
+        # Scale 8-bit uint8 array to 10-bit uint16 array
+        res_10 = scale_value(arr, 8, 10)
+        self.assertTrue(np.array_equal(res_10, np.array([0, 96, 256, 1020], dtype=np.uint16)))
+
+        # Scale back to 8-bit uint8 array
+        res_8 = scale_value(res_10, 10, 8)
+        self.assertTrue(np.array_equal(res_8, np.array([0, 24, 64, 255], dtype=np.uint8)))
+
+        # Using numpy arrays as format specification
+        arr_in = np.zeros((10, 10), dtype=np.uint8)
+        arr_out = np.zeros((10, 10), dtype=np.uint16)
+        res_format = scale_value(arr, arr_in, arr_out)
+        self.assertTrue(np.array_equal(res_format, np.array([0, 6144, 16384, 65280], dtype=np.uint16)))
+
+        # Scale mask
+        res_mask = scale_mask(arr, 8, 10)
+        self.assertTrue(np.array_equal(res_mask, np.array([0, 96, 257, 1023], dtype=np.uint16)))
+
+        # Scale delta
+        res_delta = scale_delta(arr, 8, 10)
+        self.assertTrue(np.array_equal(res_delta, np.array([0, 96, 256, 1020], dtype=np.uint16)))

--- a/tests/vstools/utils/test_scale.py
+++ b/tests/vstools/utils/test_scale.py
@@ -1,123 +1,87 @@
-from unittest import TestCase
-
 import numpy as np
 
 from vstools import Range, scale_delta, scale_mask, scale_value, vs
 
 
-class TestScale(TestCase):
-    def test_scale_value_no_change(self) -> None:
-        result = scale_value(0, 8, 8)
-        self.assertEqual(result, 0)
+def test_scale_value_no_change() -> None:
+    assert scale_value(0, 8, 8) == 0
+    assert scale_value(24, 8, 8) == 24
+    assert scale_value(64, 8, 8) == 64
+    assert scale_value(255, 8, 8) == 255
 
-        result = scale_value(24, 8, 8)
-        self.assertEqual(result, 24)
 
-        result = scale_value(64, 8, 8)
-        self.assertEqual(result, 64)
+def test_scale_value_to_10bit() -> None:
+    assert scale_value(0, 8, 10) == 0
+    assert scale_value(24, 8, 10) == 96
+    assert scale_value(64, 8, 10) == 256
+    assert scale_value(255, 8, 10) == 1020
 
-        result = scale_value(255, 8, 8)
-        self.assertEqual(result, 255)
 
-    def test_scale_value_to_10bit(self) -> None:
-        result = scale_value(0, 8, 10)
-        self.assertEqual(result, 0)
+def test_scale_value_from_10bit() -> None:
+    assert scale_value(0, 10, 8) == 0
+    assert scale_value(96, 10, 8) == 24
+    assert scale_value(256, 10, 8) == 64
+    assert scale_value(1020, 10, 8) == 255
 
-        result = scale_value(24, 8, 10)
-        self.assertEqual(result, 96)
 
-        result = scale_value(64, 8, 10)
-        self.assertEqual(result, 256)
+def test_scale_value_to_float() -> None:
+    assert scale_value(0, 8, vs.YUV444PS) == -0.0730593607305936
+    assert scale_value(24, 8, vs.YUV444PS) == 0.0365296803652968
+    assert scale_value(64, 8, vs.YUV444PS) == 0.2191780821917808
+    assert scale_value(255, 8, vs.YUV444PS) == 1.091324200913242
 
-        result = scale_value(255, 8, 10)
-        self.assertEqual(result, 1020)
 
-    def test_scale_value_from_10bit(self) -> None:
-        result = scale_value(0, 10, 8)
-        self.assertEqual(result, 0)
+def test_scale_value_from_float() -> None:
+    assert scale_value(0, vs.YUV444PS, 8) == 16
+    assert scale_value(0.1, vs.YUV444PS, 8) == 38
+    assert scale_value(0.25, vs.YUV444PS, 8) == 71
+    assert scale_value(1, vs.YUV444PS, 8) == 235
 
-        result = scale_value(96, 10, 8)
-        self.assertEqual(result, 24)
 
-        result = scale_value(256, 10, 8)
-        self.assertEqual(result, 64)
+def test_scale_value_to_limited() -> None:
+    assert scale_value(0, 8, 8, Range.FULL, Range.LIMITED) == 16
+    assert scale_value(24, 8, 8, Range.FULL, Range.LIMITED) == 37
+    assert scale_value(64, 8, 8, Range.FULL, Range.LIMITED) == 71
+    assert scale_value(255, 8, 8, Range.FULL, Range.LIMITED) == 235
 
-        result = scale_value(1020, 10, 8)
-        self.assertEqual(result, 255)
 
-    def test_scale_value_to_float(self) -> None:
-        result = scale_value(0, 8, vs.YUV444PS)
-        self.assertEqual(result, -0.0730593607305936)
+def test_scale_value_from_limited() -> None:
+    assert scale_value(0, 8, 8, Range.LIMITED, Range.FULL) == 0
+    assert scale_value(24, 8, 8, Range.LIMITED, Range.FULL) == 9
+    assert scale_value(64, 8, 8, Range.LIMITED, Range.FULL) == 56
+    assert scale_value(235, 8, 8, Range.LIMITED, Range.FULL) == 255
 
-        result = scale_value(24, 8, vs.YUV444PS)
-        self.assertEqual(result, 0.0365296803652968)
 
-        result = scale_value(64, 8, vs.YUV444PS)
-        self.assertEqual(result, 0.2191780821917808)
+def test_scale_value_numpy() -> None:
+    arr = np.array([0, 24, 64, 255], dtype=np.uint8)
 
-        result = scale_value(255, 8, vs.YUV444PS)
-        self.assertEqual(result, 1.091324200913242)
+    # Scale 8-bit uint8 array to 10-bit uint16 array
+    res_10 = scale_value(arr, 8, 10)
+    assert np.array_equal(res_10, np.array([0, 96, 256, 1020], dtype=np.uint16))
 
-    def test_scale_value_from_float(self) -> None:
-        result = scale_value(0, vs.YUV444PS, 8)
-        self.assertEqual(result, 16)
+    # Scale back to 8-bit uint8 array
+    res_8 = scale_value(res_10, 10, 8)
+    assert np.array_equal(res_8, np.array([0, 24, 64, 255], dtype=np.uint8))
 
-        result = scale_value(0.1, vs.YUV444PS, 8)
-        self.assertEqual(result, 38)
 
-        result = scale_value(0.25, vs.YUV444PS, 8)
-        self.assertEqual(result, 71)
+def test_scale_value_numpy_format() -> None:
+    arr = np.array([0, 24, 64, 255], dtype=np.uint8)
+    # Using numpy arrays as format specification
+    arr_in = np.zeros((10, 10), dtype=np.uint8)
+    arr_out = np.zeros((10, 10), dtype=np.uint16)
+    res_format = scale_value(arr, arr_in, arr_out)
+    assert np.array_equal(res_format, np.array([0, 6144, 16384, 65280], dtype=np.uint16))
 
-        result = scale_value(1, vs.YUV444PS, 8)
-        self.assertEqual(result, 235)
 
-    def test_scale_value_to_limited(self) -> None:
-        result = scale_value(0, 8, 8, Range.FULL, Range.LIMITED)
-        self.assertEqual(result, 16)
+def test_scale_mask_numpy() -> None:
+    arr = np.array([0, 24, 64, 255], dtype=np.uint8)
+    # Scale mask
+    res_mask = scale_mask(arr, 8, 10)
+    assert np.array_equal(res_mask, np.array([0, 96, 257, 1023], dtype=np.uint16))
 
-        result = scale_value(24, 8, 8, Range.FULL, Range.LIMITED)
-        self.assertEqual(result, 37)
 
-        result = scale_value(64, 8, 8, Range.FULL, Range.LIMITED)
-        self.assertEqual(result, 71)
-
-        result = scale_value(255, 8, 8, Range.FULL, Range.LIMITED)
-        self.assertEqual(result, 235)
-
-    def test_scale_value_from_limited(self) -> None:
-        result = scale_value(0, 8, 8, Range.LIMITED, Range.FULL)
-        self.assertEqual(result, 0)
-
-        result = scale_value(24, 8, 8, Range.LIMITED, Range.FULL)
-        self.assertEqual(result, 9)
-
-        result = scale_value(64, 8, 8, Range.LIMITED, Range.FULL)
-        self.assertEqual(result, 56)
-
-        result = scale_value(235, 8, 8, Range.LIMITED, Range.FULL)
-        self.assertEqual(result, 255)
-
-    def test_scale_value_numpy(self) -> None:
-        arr = np.array([0, 24, 64, 255], dtype=np.uint8)
-
-        # Scale 8-bit uint8 array to 10-bit uint16 array
-        res_10 = scale_value(arr, 8, 10)
-        self.assertTrue(np.array_equal(res_10, np.array([0, 96, 256, 1020], dtype=np.uint16)))
-
-        # Scale back to 8-bit uint8 array
-        res_8 = scale_value(res_10, 10, 8)
-        self.assertTrue(np.array_equal(res_8, np.array([0, 24, 64, 255], dtype=np.uint8)))
-
-        # Using numpy arrays as format specification
-        arr_in = np.zeros((10, 10), dtype=np.uint8)
-        arr_out = np.zeros((10, 10), dtype=np.uint16)
-        res_format = scale_value(arr, arr_in, arr_out)
-        self.assertTrue(np.array_equal(res_format, np.array([0, 6144, 16384, 65280], dtype=np.uint16)))
-
-        # Scale mask
-        res_mask = scale_mask(arr, 8, 10)
-        self.assertTrue(np.array_equal(res_mask, np.array([0, 96, 257, 1023], dtype=np.uint16)))
-
-        # Scale delta
-        res_delta = scale_delta(arr, 8, 10)
-        self.assertTrue(np.array_equal(res_delta, np.array([0, 96, 256, 1020], dtype=np.uint16)))
+def test_scale_delta_numpy() -> None:
+    arr = np.array([0, 24, 64, 255], dtype=np.uint8)
+    # Scale delta
+    res_delta = scale_delta(arr, 8, 10)
+    assert np.array_equal(res_delta, np.array([0, 96, 256, 1020], dtype=np.uint16))

--- a/vstools/exceptions/generic.py
+++ b/vstools/exceptions/generic.py
@@ -18,6 +18,10 @@ from jetpytools import (
 from ..types import HoldsVideoFormat, VideoFormatLike
 from ..vs_proxy import vs
 
+if TYPE_CHECKING:
+    from ..types import HoldsNumpyFormat
+
+
 __all__ = [
     "ClipLengthError",
     "FormatsMismatchError",
@@ -121,8 +125,14 @@ class UnsupportedVideoFormatError(_UnsupportedError):
     def __init__(
         self,
         func: FuncExcept | None,
-        wrong: VideoFormatLike | HoldsVideoFormat | Iterable[VideoFormatLike | HoldsVideoFormat],
-        correct: VideoFormatLike | HoldsVideoFormat | Iterable[VideoFormatLike | HoldsVideoFormat],
+        wrong: VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
+        correct: VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
         message: SupportsString = "Input clip must be of {correct} format, not {wrong}.",
         **kwargs: Any,
     ) -> None:
@@ -140,8 +150,8 @@ class UnsupportedVideoFormatError(_UnsupportedError):
 
         super().__init__(
             func,
-            {get_video_format(f).name for f in to_arr(wrong)},  # type: ignore[arg-type]
-            {get_video_format(f).name for f in to_arr(correct)},  # type: ignore[arg-type]
+            {get_video_format(f).name for f in to_arr(wrong)},
+            {get_video_format(f).name for f in to_arr(correct)},
             message,
             **kwargs,
         )
@@ -149,8 +159,14 @@ class UnsupportedVideoFormatError(_UnsupportedError):
     @classmethod
     def check(
         cls,
-        to_check: VideoFormatLike | HoldsVideoFormat | Iterable[VideoFormatLike | HoldsVideoFormat],
-        correct: VideoFormatLike | HoldsVideoFormat | Iterable[VideoFormatLike | HoldsVideoFormat],
+        to_check: VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
+        correct: VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
         func: FuncExcept | None = None,
         message: SupportsString | None = None,
         **kwargs: Any,
@@ -170,7 +186,7 @@ class UnsupportedVideoFormatError(_UnsupportedError):
         """
         from ..utils import get_video_format
 
-        cls._check_builder(get_video_format, to_check, correct, func, message, **kwargs)  # type: ignore[arg-type]
+        cls._check_builder(get_video_format, to_check, correct, func, message, **kwargs)
 
 
 class UnsupportedColorFamilyError(_UnsupportedError):
@@ -183,12 +199,14 @@ class UnsupportedColorFamilyError(_UnsupportedError):
         func: FuncExcept | None,
         wrong: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.ColorFamily
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.ColorFamily],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily],
         correct: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.ColorFamily
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.ColorFamily] = vs.YUV,
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily] = vs.YUV,
         message: SupportsString = "Input clip must be of {correct} color family, not {wrong}.",
         **kwargs: Any,
     ) -> None:
@@ -206,8 +224,8 @@ class UnsupportedColorFamilyError(_UnsupportedError):
 
         super().__init__(
             func,
-            {get_color_family(c).name for c in to_arr(wrong)},  # type: ignore[arg-type]
-            {get_color_family(c).name for c in to_arr(correct)},  # type: ignore[arg-type]
+            {get_color_family(c).name for c in to_arr(wrong)},
+            {get_color_family(c).name for c in to_arr(correct)},
             message,
             **kwargs,
         )
@@ -217,12 +235,14 @@ class UnsupportedColorFamilyError(_UnsupportedError):
         cls,
         to_check: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.ColorFamily
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.ColorFamily],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily],
         correct: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.ColorFamily
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.ColorFamily],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily],
         func: FuncExcept | None = None,
         message: SupportsString | None = None,
         **kwargs: Any,
@@ -242,7 +262,7 @@ class UnsupportedColorFamilyError(_UnsupportedError):
         """
         from ..utils import get_color_family
 
-        cls._check_builder(get_color_family, to_check, correct, func, message, **kwargs)  # type: ignore[arg-type]
+        cls._check_builder(get_color_family, to_check, correct, func, message, **kwargs)
 
 
 class UnsupportedSampleTypeError(_UnsupportedError):
@@ -255,12 +275,14 @@ class UnsupportedSampleTypeError(_UnsupportedError):
         func: FuncExcept | None,
         wrong: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.SampleType
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.SampleType],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.SampleType],
         correct: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.SampleType
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.SampleType],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.SampleType],
         message: SupportsString = "Input clip must be of {correct} sample type, not {wrong}.",
         **kwargs: Any,
     ) -> None:
@@ -278,8 +300,8 @@ class UnsupportedSampleTypeError(_UnsupportedError):
 
         super().__init__(
             func,
-            {get_sample_type(c).name for c in to_arr(wrong)},  # type: ignore[arg-type]
-            {get_sample_type(c).name for c in to_arr(correct)},  # type: ignore[arg-type]
+            {get_sample_type(c).name for c in to_arr(wrong)},
+            {get_sample_type(c).name for c in to_arr(correct)},
             message,
             **kwargs,
         )
@@ -289,12 +311,14 @@ class UnsupportedSampleTypeError(_UnsupportedError):
         cls,
         to_check: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.SampleType
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.SampleType],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.SampleType],
         correct: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.SampleType
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.SampleType],
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.SampleType],
         func: FuncExcept | None = None,
         message: SupportsString | None = None,
         **kwargs: Any,
@@ -314,7 +338,7 @@ class UnsupportedSampleTypeError(_UnsupportedError):
         """
         from ..utils import get_sample_type
 
-        cls._check_builder(get_sample_type, to_check, correct, func, message, **kwargs)  # type: ignore[arg-type]
+        cls._check_builder(get_sample_type, to_check, correct, func, message, **kwargs)
 
 
 class UnsupportedSubsamplingError(_UnsupportedError):
@@ -325,8 +349,16 @@ class UnsupportedSubsamplingError(_UnsupportedError):
     def __init__(
         self,
         func: FuncExcept,
-        wrong: str | VideoFormatLike | HoldsVideoFormat | Iterable[str | VideoFormatLike | HoldsVideoFormat],
-        correct: str | VideoFormatLike | HoldsVideoFormat | Iterable[str | VideoFormatLike | HoldsVideoFormat],
+        wrong: str
+        | VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[str | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
+        correct: str
+        | VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[str | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
         message: SupportsString = "Input clip must be of {correct} subsampling, not {wrong}.",
         **kwargs: Any,
     ) -> None:
@@ -344,8 +376,8 @@ class UnsupportedSubsamplingError(_UnsupportedError):
 
         super().__init__(
             func,
-            {f if isinstance(f, str) else get_subsampling(f) for f in to_arr(wrong)},  # type: ignore[arg-type]
-            {f if isinstance(f, str) else get_subsampling(f) for f in to_arr(correct)},  # type: ignore[arg-type]
+            {f if isinstance(f, str) else get_subsampling(f) for f in to_arr(wrong)},
+            {f if isinstance(f, str) else get_subsampling(f) for f in to_arr(correct)},
             message,
             **kwargs,
         )
@@ -353,8 +385,14 @@ class UnsupportedSubsamplingError(_UnsupportedError):
     @classmethod
     def check(
         cls,
-        to_check: VideoFormatLike | HoldsVideoFormat | Iterable[VideoFormatLike | HoldsVideoFormat],
-        correct: VideoFormatLike | HoldsVideoFormat | Iterable[VideoFormatLike | HoldsVideoFormat],
+        to_check: VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
+        correct: VideoFormatLike
+        | HoldsVideoFormat
+        | HoldsNumpyFormat
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat],
         func: FuncExcept | None = None,
         message: SupportsString | None = None,
         **kwargs: Any,
@@ -374,7 +412,7 @@ class UnsupportedSubsamplingError(_UnsupportedError):
         """
         from ..utils import get_subsampling
 
-        cls._check_builder(get_subsampling, to_check, correct, func, message, **kwargs)  # type: ignore[arg-type]
+        cls._check_builder(get_subsampling, to_check, correct, func, message, **kwargs)
 
 
 class UnsupportedFramerateError(_UnsupportedError):

--- a/vstools/functions/funcs.py
+++ b/vstools/functions/funcs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
 
 from jetpytools import FuncExcept, cachedproperty, normalize_seq, to_arr
 
@@ -23,6 +24,9 @@ from ..types import HoldsVideoFormat, Planes, VideoFormatLike
 from ..utils import check_variable, get_color_family, get_depth, normalize_planes
 from ..vs_proxy import VSObject, vs
 from .utils import depth, join, plane
+
+if TYPE_CHECKING:
+    from ..types import HoldsNumpyFormat
 
 __all__ = ["FunctionUtil"]
 
@@ -56,8 +60,9 @@ class FunctionUtil(VSObject, list[int]):
         planes: Planes = None,
         color_family: VideoFormatLike
         | HoldsVideoFormat
+        | HoldsNumpyFormat
         | vs.ColorFamily
-        | Iterable[VideoFormatLike | HoldsVideoFormat | vs.ColorFamily]
+        | Iterable[VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily]
         | None = None,
         bitdepth: int | range | tuple[int, int] | set[int] | None = None,
         *,
@@ -101,7 +106,7 @@ class FunctionUtil(VSObject, list[int]):
         all_color_family: list[vs.ColorFamily] | None
 
         if color_family is not None:
-            all_color_family = [get_color_family(c) for c in to_arr(color_family)]  # type: ignore[arg-type]
+            all_color_family = [get_color_family(c) for c in to_arr(color_family)]
             if not set(all_color_family) & {vs.YUV, vs.RGB}:
                 planes = 0
         else:

--- a/vstools/types/generic.py
+++ b/vstools/types/generic.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from jetpytools import MissingT
 
 from ..vs_proxy import vs
 from .builtins import Planes
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
 __all__ = [
     "AudioNodeIterable",
     "GenericVSFunction",
+    "HoldsNumpyFormat",
     "HoldsPropValue",
     "HoldsVideoFormat",
     "MissingT",
@@ -28,6 +32,12 @@ __all__ = [
 type VideoNodeIterable = vs.VideoNode | Iterable[VideoNodeIterable]
 type AudioNodeIterable = vs.AudioNode | Iterable[AudioNodeIterable]
 type RawNodeIterable = vs.RawNode | Iterable[RawNodeIterable]
+
+
+type HoldsNumpyFormat = npt.NDArray[Any] | npt.DTypeLike
+"""
+Numpy types from which a VideoFormat can be retrieved.
+"""
 
 
 VideoFormatLike = vs.PresetVideoFormat | vs.VideoFormat

--- a/vstools/utils/info.py
+++ b/vstools/utils/info.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import SupportsFloat, SupportsInt
+from typing import TYPE_CHECKING, Any, SupportsFloat, SupportsInt
 
-from jetpytools import CustomNotImplementedError, fallback, mod_x
+from jetpytools import CustomNotImplementedError, CustomTypeError, fallback, mod_x
+
+from vsjetpack import TypeIs
 
 from ..enums import Dar, Sar
 from ..exceptions import UnsupportedColorFamilyError
 from ..types import HoldsVideoFormat, VideoFormatLike
 from ..vs_proxy import vs
+
+if TYPE_CHECKING:
+    from ..types import HoldsNumpyFormat
 
 __all__ = [
     "get_color_family",
@@ -23,6 +28,14 @@ __all__ = [
     "get_video_format",
     "get_w",
 ]
+
+
+def _is_int_like(x: Any) -> TypeIs[SupportsInt]:
+    try:
+        int(x)
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 def get_var_infos(frame: vs.VideoNode | vs.VideoFrame) -> tuple[vs.VideoFormat, int, int]:
@@ -42,7 +55,10 @@ def get_var_infos(frame: vs.VideoNode | vs.VideoFrame) -> tuple[vs.VideoFormat, 
 
 
 def get_video_format(
-    value: SupportsInt | VideoFormatLike | HoldsVideoFormat, /, *, sample_type: int | vs.SampleType | None = None
+    value: SupportsInt | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    /,
+    *,
+    sample_type: int | vs.SampleType | None = None,
 ) -> vs.VideoFormat:
     """
     Retrieve a VapourSynth VideoFormat object from various input types.
@@ -54,9 +70,11 @@ def get_video_format(
                - A unique format ID
                - A VideoFormat-like object
                - An object holding a VideoFormat (i.e., exposing a `format` attribute)
+               - A NumPy array (resolving to its dtype)
+               - Any object compatible with `numpy.typing.DTypeLike` (e.g. `np.uint8`, `"uint8"`, etc.)
 
-        sample_type: Optional override for the sample type. Accepts either an integer or a SampleType. If None, the
-            default or inferred sample type is used.
+        sample_type: Optional override for the sample type. Accepts either an integer or a SampleType.
+            If None, the default or inferred sample type is used.
 
     Returns:
         A VideoFormat object derived from the input.
@@ -67,7 +85,7 @@ def get_video_format(
     if sample_type is not None:
         sample_type = vs.SampleType(sample_type)
 
-    if isinstance(value, SupportsInt):
+    if _is_int_like(value):
         value = int(value)
 
         if value > 32 or value == 0:
@@ -78,13 +96,26 @@ def get_video_format(
 
         return vs.core.query_video_format(vs.YUV, sample_type, value)
 
+    if isinstance(value, (vs.VideoNode, vs.VideoFrame)):
+        return value.format.replace(sample_type=sample_type) if sample_type is not None else value.format
+
+    import numpy as np
+
+    dtype = value.dtype if isinstance(value, np.ndarray) else np.dtype(value)
+
     if sample_type is not None:
-        return value.format.replace(sample_type=sample_type)
+        sample_type = vs.SampleType(sample_type)
+    elif dtype.kind in "ui":
+        sample_type = vs.INTEGER
+    elif dtype.kind == "f":
+        sample_type = vs.FLOAT
+    else:
+        raise CustomTypeError(f"Unsupported numpy dtype: {dtype}", get_video_format)
 
-    return value.format
+    return vs.core.query_video_format(vs.YUV, sample_type, dtype.itemsize * 8)
 
 
-def get_depth(clip: VideoFormatLike | HoldsVideoFormat, /) -> int:
+def get_depth(clip: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat, /) -> int:
     """
     Get the bitdepth of a given clip or value.
     """
@@ -92,7 +123,7 @@ def get_depth(clip: VideoFormatLike | HoldsVideoFormat, /) -> int:
     return get_video_format(clip).bits_per_sample
 
 
-def get_sample_type(clip: VideoFormatLike | HoldsVideoFormat | vs.SampleType, /) -> vs.SampleType:
+def get_sample_type(clip: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.SampleType, /) -> vs.SampleType:
     """
     Get the sample type of a given clip.
     """
@@ -103,7 +134,7 @@ def get_sample_type(clip: VideoFormatLike | HoldsVideoFormat | vs.SampleType, /)
     return get_video_format(clip).sample_type
 
 
-def get_color_family(clip: VideoFormatLike | HoldsVideoFormat | vs.ColorFamily, /) -> vs.ColorFamily:
+def get_color_family(clip: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily, /) -> vs.ColorFamily:
     """
     Get the color family of a given clip.
     """
@@ -157,7 +188,7 @@ def get_resolutions(clip: vs.VideoNode | vs.VideoFrame) -> tuple[tuple[int, int,
     return tuple((plane, *get_plane_sizes(clip, plane)) for plane in range(clip.format.num_planes))
 
 
-def get_subsampling(clip: VideoFormatLike | HoldsVideoFormat, /) -> str:
+def get_subsampling(clip: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat, /) -> str:
     """
     Get the subsampling of a clip as a human-readable name.
 

--- a/vstools/utils/scale.py
+++ b/vstools/utils/scale.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, overload
+
 from jetpytools import clamp, normalize_seq
 
 from ..enums import Range, RangeLike
 from ..types import HoldsVideoFormat, VideoFormatLike
 from ..vs_proxy import vs
 from .info import get_color_family, get_depth, get_video_format
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+
+    from ..types import HoldsNumpyFormat
 
 __all__ = [
     "get_lowest_value",
@@ -20,21 +28,47 @@ __all__ = [
 ]
 
 
+@overload
 def scale_value(
     value: float,
-    input_depth: int | VideoFormatLike | HoldsVideoFormat,
-    output_depth: int | VideoFormatLike | HoldsVideoFormat,
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
     range_in: RangeLike | None = None,
     range_out: RangeLike | None = None,
     scale_offsets: bool = True,
     chroma: bool = False,
-    family: VideoFormatLike | HoldsVideoFormat | vs.ColorFamily | None = None,
-) -> float:
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
+) -> float: ...
+
+
+@overload
+def scale_value(
+    value: npt.NDArray[Any],
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    range_in: RangeLike | None = None,
+    range_out: RangeLike | None = None,
+    scale_offsets: bool = True,
+    chroma: bool = False,
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
+) -> npt.NDArray[Any]: ...
+
+
+def scale_value(
+    value: float | npt.NDArray[Any],
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    range_in: RangeLike | None = None,
+    range_out: RangeLike | None = None,
+    scale_offsets: bool = True,
+    chroma: bool = False,
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
+) -> float | npt.NDArray[Any]:
     """
     Converts the value to the specified bit depth, or bit depth of the clip/format specified.
 
     Args:
-        value: Value to scale.
+        value: Value to scale. Can be a single float or a NumPy array.
         input_depth: Input bit depth, or clip, frame, format from where to get it.
         output_depth: Output bit depth, or clip, frame, format from where to get it.
         range_in: Color range of the input value
@@ -45,10 +79,26 @@ def scale_value(
         family: Which color family to assume for calculations.
 
     Returns:
-        Scaled value.
+        Scaled value or scaled NumPy array.
     """
+    import numpy as np
 
-    out_value = float(value)
+    def _vs_fmt_to_dtype(
+        fmt: vs.VideoFormat,
+    ) -> np.dtype[np.float32] | np.dtype[np.float16] | np.dtype[np.uint32] | np.dtype[np.uint16] | np.dtype[np.uint8]:
+        match fmt.bits_per_sample, fmt.sample_type:
+            case 32, vs.FLOAT:
+                return np.dtype(np.float32)
+            case 16, vs.FLOAT:
+                return np.dtype(np.float16)
+            case 32, vs.INTEGER:
+                return np.dtype(np.uint32)
+            case bits, vs.INTEGER if bits > 8:
+                return np.dtype(np.uint16)
+            case _:
+                return np.dtype(np.uint8)
+
+    out_value = value.astype(np.float64) if isinstance(value, np.ndarray) else float(value)
 
     in_fmt = get_video_format(input_depth)
     out_fmt = get_video_format(output_depth)
@@ -74,8 +124,8 @@ def scale_value(
     else:
         range_out = Range.from_param(range_out, scale_value)
 
-    if input_depth == output_depth and range_in == range_out and in_fmt.sample_type == out_fmt.sample_type:
-        return out_value
+    if in_fmt == out_fmt and range_in == range_out and in_fmt.sample_type == out_fmt.sample_type:
+        return out_value.astype(_vs_fmt_to_dtype(out_fmt)) if isinstance(out_value, np.ndarray) else out_value
 
     if vs.RGB in (in_fmt.color_family, out_fmt.color_family, family):
         chroma = False
@@ -100,53 +150,95 @@ def scale_value(
             out_value += 16 << (out_fmt.bits_per_sample - 8)
 
     if out_fmt.sample_type is vs.INTEGER:
-        out_value = clamp(round(out_value), 0, get_peak_value(out_fmt, range_in=Range.FULL))
+        peak = get_peak_value(out_fmt, range_in=Range.FULL)
+        if isinstance(out_value, np.ndarray):
+            out_value = out_value.round().clip(0, peak).astype(_vs_fmt_to_dtype(out_fmt))
+        else:
+            out_value = clamp(round(out_value), 0, peak)
+    elif isinstance(out_value, np.ndarray):
+        out_value = out_value.astype(_vs_fmt_to_dtype(out_fmt))
 
     return out_value
 
 
+@overload
 def scale_mask(
     value: float,
     input_depth: int | VideoFormatLike | HoldsVideoFormat,
     output_depth: int | VideoFormatLike | HoldsVideoFormat,
-) -> float:
+) -> float: ...
+
+
+@overload
+def scale_mask(
+    value: npt.NDArray[Any],
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+) -> npt.NDArray[Any]: ...
+
+
+def scale_mask(
+    value: float | npt.NDArray[Any],
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+) -> float | npt.NDArray[Any]:
     """
     Converts the value to the specified bit depth, or bit depth of the clip/format specified.
     Intended for mask clips which are always full range.
 
     Args:
-        value: Value to scale.
+        value: Value to scale. Can be a single float or a NumPy array.
         input_depth: Input bit depth, or clip, frame, format from where to get it.
         output_depth: Output bit depth, or clip, frame, format from where to get it.
 
     Returns:
-        Scaled value.
+        Scaled value or scaled NumPy array.
     """
 
     return scale_value(value, input_depth, output_depth, Range.FULL, Range.FULL)
 
 
+@overload
 def scale_delta(
     value: float,
-    input_depth: int | VideoFormatLike | HoldsVideoFormat,
-    output_depth: int | VideoFormatLike | HoldsVideoFormat,
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
     range_in: RangeLike | None = None,
     range_out: RangeLike | None = None,
-) -> float:
+) -> float: ...
+
+
+@overload
+def scale_delta(
+    value: npt.NDArray[Any],
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    range_in: RangeLike | None = None,
+    range_out: RangeLike | None = None,
+) -> npt.NDArray[Any]: ...
+
+
+def scale_delta(
+    value: float | npt.NDArray[Any],
+    input_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    output_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
+    range_in: RangeLike | None = None,
+    range_out: RangeLike | None = None,
+) -> float | npt.NDArray[Any]:
     """
     Converts the value to the specified bit depth, or bit depth of the clip/format specified.
     Uses the clip's range (if only one clip is passed) for both depths.
     Intended for filter thresholds.
 
     Args:
-        value: Value to scale.
+        value: Value to scale. Can be a single float or a NumPy array.
         input_depth: Input bit depth, or clip, frame, format from where to get it.
         output_depth: Output bit depth, or clip, frame, format from where to get it.
         range_in: Color range of the input value
         range_out: Color range of the desired output.
 
     Returns:
-        Scaled value.
+        Scaled value or scaled NumPy array.
     """
 
     if isinstance(input_depth, vs.VideoNode) != isinstance(output_depth, vs.VideoNode):
@@ -163,10 +255,10 @@ def scale_delta(
 
 
 def get_lowest_value(
-    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat,
+    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
     chroma: bool = False,
     range_in: RangeLike | None = None,
-    family: VideoFormatLike | HoldsVideoFormat | vs.ColorFamily | None = None,
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
 ) -> float:
     """
     Returns the lowest value for the specified bit depth, or bit depth of the clip/format specified.
@@ -205,9 +297,9 @@ def get_lowest_value(
 
 
 def get_lowest_values(
-    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat,
+    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
     range_in: RangeLike | None = None,
-    family: VideoFormatLike | HoldsVideoFormat | vs.ColorFamily | None = None,
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
     mask: bool = False,
 ) -> list[float]:
     """
@@ -225,7 +317,7 @@ def get_lowest_values(
     )
 
 
-def get_neutral_value(clip_or_depth: int | VideoFormatLike | HoldsVideoFormat) -> float:
+def get_neutral_value(clip_or_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat) -> float:
     """
     Returns the neutral point value (e.g. as used by std.MakeDiff) for the specified bit depth,
     or bit depth of the clip/format specified.
@@ -245,7 +337,7 @@ def get_neutral_value(clip_or_depth: int | VideoFormatLike | HoldsVideoFormat) -
     return 1 << (get_depth(fmt) - 1)
 
 
-def get_neutral_values(clip_or_depth: int | VideoFormatLike | HoldsVideoFormat) -> list[float]:
+def get_neutral_values(clip_or_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat) -> list[float]:
     """
     Get the neutral values of all planes of a specified format.
     """
@@ -255,10 +347,10 @@ def get_neutral_values(clip_or_depth: int | VideoFormatLike | HoldsVideoFormat) 
 
 
 def get_peak_value(
-    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat,
+    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
     chroma: bool = False,
     range_in: RangeLike | None = None,
-    family: VideoFormatLike | HoldsVideoFormat | vs.ColorFamily | None = None,
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
 ) -> float:
     """
     Returns the peak value for the specified bit depth, or bit depth of the clip/format specified.
@@ -297,9 +389,9 @@ def get_peak_value(
 
 
 def get_peak_values(
-    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat,
+    clip_or_depth: int | VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat,
     range_in: RangeLike | None = None,
-    family: VideoFormatLike | HoldsVideoFormat | vs.ColorFamily | None = None,
+    family: VideoFormatLike | HoldsVideoFormat | HoldsNumpyFormat | vs.ColorFamily | None = None,
     mask: bool = False,
 ) -> list[float]:
     """


### PR DESCRIPTION
- Extend `get_video_format` to resolve NumPy arrays, dtypes, and DTypeLike strings/types.
- Update `scale_value`, `scale_mask`, and `scale_delta` to scale NumPy arrays.
- Add `HoldsNumpyFormat` type alias and update function/exception signatures to accept it.