### PR TITLE
fix: use global provider folder for `get_model_folder`

### DIFF
--- a/vsscale/mlrt/settings.py
+++ b/vsscale/mlrt/settings.py
@@ -82,7 +82,7 @@ def is_global_in_env(filetype: str) -> bool:
 
 
 def get_model_folder(provider: str, version: str | None = None) -> Path:
-    folder = get_provider_folder() / provider.lower()
+    folder = get_provider_folder(global_=True) / provider.lower()
 
     if version is None:
         latest = sorted(folder.glob("*"), reverse=True)


### PR DESCRIPTION
The documentation for `get_provider_folder` shows that it refers to the global cache location. However, this is misleading, because it is only true when `global_` is True. `global_` is never true when `get_model_folder` is called.

This change sets `global_` to true when `get_model_folder` calls `get_provider_folder` so that the global cache location is used. The local cache location is underneath the directory of the current Vapoursynth script, which will lead to confusing errors if auto-download is off (which it appears to be at every call site), or repeated downloads of the potentially large onnx files when auto-download is on.