### PR TITLE
EEDI3: add multiple backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,22 @@ Most of these plugins are now available as Python packages on PyPI and can be in
 
 Most extras are hierarchical. For example, `denoise` includes all plugins from `aa`, which in turn includes `mask`, and so on.
 
-| Extra             | Purpose              | Included Plugins / Packages                                                           |
-| :---------------- | :------------------- | :------------------------------------------------------------------------------------ |
-| **`source`**      | Clip Indexing        | `bestsource`, `ffms2`, `lsmas`, `d2vsource`, `dvdsrc2`                                |
-| **`kernels`**     | Resizing             | `resize2`, `descale`, `vs-placebo`                                                    |
-| **`rg`**          | Repair & Smoothing   | `awarp`, `zsmooth` (+ `kernels`, `expr`)                                              |
-| **`mask`**        | Masking              | `adaptivegrain`, `edgemasks`, `hysteresis`, `subtext` (+ `source`, `rg`)              |
-| **`aa`**          | Anti-aliasing        | `bwdif`, `eedi3`, `sangnom`, `sneedif`, `znedi3` (+ `mask`)                           |
-| **`denoise`**     | Denoising            | `bm3d`, `dfttest2`, `deblock`, `mvtools`, `nlm-ispc` (+ `aa`)                         |
-| **`deband`**      | Debanding            | `vsnoise` (+ `denoise`)                                                               |
-| **`deinterlace`** | Deinterlacing        | `dmetrics`, `vivtc` (+ `denoise`)                                                     |
-| **`full`**        | All CPU-based extras | All of the above                                                                      |
-| **`gpu`**         | Generic GPU          | `ncnn`, `ort`                                                                         |
-| **`cl`**          | Open CL              | `vszipcl`                                                                             |
-| **`nvidia`**      | NVIDIA GPU           | `bm3dcuda`, `bilateralgpu`, `dfttest2-[nvrtc,cuda]`, `ort-cuda`, `trt{-rtx}` (+ `cl`) |
-| **`amd`**         | AMD GPU              | `bm3dhip`, `dfttest2-[hiprtc,hipfft]` (+ `cl`, `gpu`)                                 |
+| Extra             | Purpose              | Included Plugins / Packages                                                                     |
+| :---------------- | :------------------- | :---------------------------------------------------------------------------------------------- |
+| **`source`**      | Clip Indexing        | `bestsource`, `ffms2`, `lsmas`, `d2vsource`, `dvdsrc2`                                          |
+| **`kernels`**     | Resizing             | `resize2`, `descale`, `vs-placebo`                                                              |
+| **`rg`**          | Repair & Smoothing   | `awarp`, `zsmooth` (+ `kernels`, `expr`)                                                        |
+| **`mask`**        | Masking              | `adaptivegrain`, `edgemasks`, `hysteresis`, `subtext` (+ `source`, `rg`)                        |
+| **`aa`**          | Anti-aliasing        | `bwdif`, `sangnom`, `sneedif`, `znedi3` (+ `mask`)                                              |
+| **`denoise`**     | Denoising            | `bm3d`, `dfttest2`, `deblock`, `mvtools`, `nlm-ispc` (+ `aa`)                                   |
+| **`deband`**      | Debanding            | `vsnoise` (+ `denoise`)                                                                         |
+| **`deinterlace`** | Deinterlacing        | `dmetrics`, `vivtc` (+ `denoise`)                                                               |
+| **`full`**        | All CPU-based extras | All of the above                                                                                |
+| **`gpu`**         | Generic GPU          | `ort`                                                                                           |
+| **`cl`**          | Open CL              | `vszipcl`                                                                                       |
+| **`vulkan`**      | Vulkan Devices       | `eedi3vk2`, `ncnn`                                                                              |
+| **`nvidia`**      | NVIDIA GPU           | `bm3dcuda`, `bilateralgpu`, `dfttest2-[nvrtc,cuda]`, `ort-cuda`, `trt{-rtx}` (+ `cl`, `vulkan`) |
+| **`amd`**         | AMD GPU              | `bm3dhip`, `dfttest2-[hiprtc,hipfft]` (+ `gpu`, `cl`, `vulkan`)                                 |
 
 > [!IMPORTANT]
 > Some plugins distribute their wheels through our custom package index instead of PyPI.
@@ -72,22 +73,23 @@ Most extras are hierarchical. For example, `denoise` includes all plugins from `
 
 Not all extras have prebuilt wheels on every platform:
 
-| Extra         | Windows x64 | Linux (glibc 2.35+) | Linux (musl 1.2+) | macOS (Intel/ARM) 15.0+ |
-| :------------ | :---------: | :-----------------: | :---------------: | :---------------------: |
-| `source`      |     ✅      |         ✅          |        ✅         |           ✅            |
-| `kernels`     |     ✅      |         ✅          |        ✅         |           ✅            |
-| `rg`          |     ✅      |         ✅          |        ✅         |           ✅            |
-| `mask`        |     ✅      |         ✅          |        ✅         |           ✅            |
-| `scale`       |     ✅      |         ✅          |        ❌         |           ✅            |
-| `aa`          |     ✅      |         ✅          |        ❌         |           ✅            |
-| `denoise`     |     ✅      |         ✅          |        ❌         |           ✅            |
-| `deband`      |     ✅      |         ✅          |        ❌         |           ✅            |
-| `deinterlace` |     ✅      |         ✅          |        ❌         |           ✅            |
-| `full`        |     ✅      |         ✅          |        ❌         |           ✅            |
-| `gpu`         |     ✅      |         ✅          |        ❌         |           ✅            |
-| `cl`          |     ✅      |         ✅          |        ❌         |           ✅            |
-| `nvidia`      |   ⚠️[^1]    |         ✅          |        ❌         |           ❌            |
-| `amd`         |     ✅      |         ✅          |        ❌         |           ❌            |
+| Extra         | Windows x64 | Linux (glibc 2.35+) | Linux (musl 1.2+) | macOS (x64/ARM) 15.0+ |
+| :------------ | :---------: | :-----------------: | :---------------: | :-------------------: |
+| `source`      |     ✅      |         ✅          |        ✅         |          ✅           |
+| `kernels`     |     ✅      |         ✅          |        ✅         |          ✅           |
+| `rg`          |     ✅      |         ✅          |        ✅         |          ✅           |
+| `mask`        |     ✅      |         ✅          |        ✅         |          ✅           |
+| `scale`       |     ✅      |         ✅          |        ❌         |          ✅           |
+| `aa`          |     ✅      |         ✅          |        ❌         |          ✅           |
+| `denoise`     |     ✅      |         ✅          |        ❌         |          ✅           |
+| `deband`      |     ✅      |         ✅          |        ❌         |          ✅           |
+| `deinterlace` |     ✅      |         ✅          |        ❌         |          ✅           |
+| `full`        |     ✅      |         ✅          |        ❌         |          ✅           |
+| `gpu`         |     ✅      |         ✅          |        ❌         |          ✅           |
+| `cl`          |     ✅      |         ✅          |        ❌         |          ✅           |
+| `vulkan`      |     ✅      |         ✅          |        ❌         |          ✅           |
+| `nvidia`      |     ✅      |       ⚠️[^1]        |        ❌         |          ❌           |
+| `amd`         |     ✅      |         ✅          |        ❌         |          ❌           |
 
 > [!TIP]
 > If a plugin is unavailable for your platform, you may need to build it manually.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ scale = [
 aa = [
     "vsjetpack[scale]",
     "vapoursynth-bwdif>=5.0",
-    "vapoursynth-eedi3>=9.0",
     "vapoursynth-sangnom>=43",
     "vapoursynth-sneedif>=4.2",
     "vapoursynth-znedi3>=2.1",
@@ -137,10 +136,11 @@ deinterlace = [
     "vapoursynth-vivtc>=2.0",
 ]
 deband = ["vsjetpack[denoise]", "vsnoise>=1.2"]
-gpu = ["vapoursynth-mlrt-ncnn>=15.16", "vapoursynth-mlrt-ort>=15.16"]
+gpu = ["vapoursynth-mlrt-ort>=15.16"]
 cl = ["vapoursynth-vszipcl>=1.2.0"]
+vulkan = ["vapoursynth-eedi3vk2>=1.0", "vapoursynth-mlrt-ncnn>=15.16"]
 nvidia = [
-    "vsjetpack[cl]",
+    "vsjetpack[cl,vulkan]",
     "onnx>=1.21.0",
     "onnxconverter-common>=1.16.0",
     "cuda-python>=13.0.0,<14.0.0",
@@ -160,7 +160,7 @@ nvidia = [
     "tensorrt-rtx-cu13-bindings",
 ]
 amd = [
-    "vsjetpack[cl,gpu]",
+    "vsjetpack[gpu,cl,vulkan]",
     "dfttest2[hipfft,hiprtc]>=10",
     "vapoursynth-bm3dhip>=2.16",
     "vapoursynth-mlrt-migx>=15.16 ; platform_system == 'Linux'",

--- a/stubs/vapoursynth/__init__.pyi
+++ b/stubs/vapoursynth/__init__.pyi
@@ -1816,10 +1816,10 @@ class VideoNode(RawNode):
     edgemasks: Final[_edgemasks._VideoNode_bound.Plugin]
     """Creates an edge mask using various operators"""
 # </attribute/VideoNode_bound/edgemasks>
-# <attribute/VideoNode_bound/eedi3m>
-    eedi3m: Final[_eedi3m._VideoNode_bound.Plugin]
-    """Enhanced Edge Directed Interpolation 3"""
-# </attribute/VideoNode_bound/eedi3m>
+# <attribute/VideoNode_bound/eedi3vk2>
+    eedi3vk2: Final[_eedi3vk2._VideoNode_bound.Plugin]
+    """Enhanced Edge Directed Interpolation 3, using Vulkan compute"""
+# </attribute/VideoNode_bound/eedi3vk2>
 # <attribute/VideoNode_bound/fmtc>
     fmtc: Final[_fmtc._VideoNode_bound.Plugin]
     """Format converter"""
@@ -2098,10 +2098,10 @@ class Core:
     edgemasks: Final[_edgemasks._Core_bound.Plugin]
     """Creates an edge mask using various operators"""
 # </attribute/Core_bound/edgemasks>
-# <attribute/Core_bound/eedi3m>
-    eedi3m: Final[_eedi3m._Core_bound.Plugin]
-    """Enhanced Edge Directed Interpolation 3"""
-# </attribute/Core_bound/eedi3m>
+# <attribute/Core_bound/eedi3vk2>
+    eedi3vk2: Final[_eedi3vk2._Core_bound.Plugin]
+    """Enhanced Edge Directed Interpolation 3, using Vulkan compute"""
+# </attribute/Core_bound/eedi3vk2>
 # <attribute/Core_bound/ffms2>
     ffms2: Final[_ffms2._Core_bound.Plugin]
     """FFmpegSource 2 for VapourSynth"""
@@ -2793,19 +2793,19 @@ class _edgemasks:
 
 # </implementation/edgemasks>
 
-# <implementation/eedi3m>
-class _eedi3m:
+# <implementation/eedi3vk2>
+class _eedi3vk2:
     class _Core_bound:
         class Plugin(_VSPlugin):
             @_Wrapper.Function
-            def EEDI3(self, /, clip: VideoNode, field: _IntLike, dh: _IntLike | None = None, planes: _IntLike | _SequenceLike[_IntLike] | None = None, alpha: _FloatLike | None = None, beta: _FloatLike | None = None, gamma: _FloatLike | None = None, nrad: _IntLike | None = None, mdis: _IntLike | None = None, hp: _IntLike | None = None, ucubic: _IntLike | None = None, cost3: _IntLike | None = None, vcheck: _IntLike | None = None, vthresh0: _FloatLike | None = None, vthresh1: _FloatLike | None = None, vthresh2: _FloatLike | None = None, sclip: VideoNode | None = None, mclip: VideoNode | None = None, opt: _IntLike | None = None) -> VideoNode: ...
+            def EEDI3(self, /, clip: VideoNode, field: _IntLike, dh: _IntLike | None = None, planes: _IntLike | _SequenceLike[_IntLike] | None = None, alpha: _FloatLike | None = None, beta: _FloatLike | None = None, gamma: _FloatLike | None = None, nrad: _IntLike | None = None, mdis: _IntLike | None = None, hp: _IntLike | None = None, vcheck: _IntLike | None = None, vthresh0: _FloatLike | None = None, vthresh1: _FloatLike | None = None, vthresh2: _FloatLike | None = None, sclip: VideoNode | None = None, mclip: VideoNode | None = None, device_index: _IntLike | None = None, list_device: _IntLike | None = None, num_streams: _IntLike | None = None) -> VideoNode: ...
 
     class _VideoNode_bound:
         class Plugin(_VSPlugin):
             @_Wrapper.Function
-            def EEDI3(self, /, field: _IntLike, dh: _IntLike | None = None, planes: _IntLike | _SequenceLike[_IntLike] | None = None, alpha: _FloatLike | None = None, beta: _FloatLike | None = None, gamma: _FloatLike | None = None, nrad: _IntLike | None = None, mdis: _IntLike | None = None, hp: _IntLike | None = None, ucubic: _IntLike | None = None, cost3: _IntLike | None = None, vcheck: _IntLike | None = None, vthresh0: _FloatLike | None = None, vthresh1: _FloatLike | None = None, vthresh2: _FloatLike | None = None, sclip: VideoNode | None = None, mclip: VideoNode | None = None, opt: _IntLike | None = None) -> VideoNode: ...
+            def EEDI3(self, /, field: _IntLike, dh: _IntLike | None = None, planes: _IntLike | _SequenceLike[_IntLike] | None = None, alpha: _FloatLike | None = None, beta: _FloatLike | None = None, gamma: _FloatLike | None = None, nrad: _IntLike | None = None, mdis: _IntLike | None = None, hp: _IntLike | None = None, vcheck: _IntLike | None = None, vthresh0: _FloatLike | None = None, vthresh1: _FloatLike | None = None, vthresh2: _FloatLike | None = None, sclip: VideoNode | None = None, mclip: VideoNode | None = None, device_index: _IntLike | None = None, list_device: _IntLike | None = None, num_streams: _IntLike | None = None) -> VideoNode: ...
 
-# </implementation/eedi3m>
+# </implementation/eedi3vk2>
 
 # <implementation/ffms2>
 class _ffms2:

--- a/uv.lock
+++ b/uv.lock
@@ -2375,21 +2375,21 @@ wheels = [
 ]
 
 [[package]]
-name = "vapoursynth-eedi3"
-version = "10.0"
+name = "vapoursynth-eedi3vk2"
+version = "1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "vapoursynth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/5d/d497fef0bb613aca741ca15b3dce2a9fc743f44e9be400eb51411d7a7092/vapoursynth_eedi3-10.0.tar.gz", hash = "sha256:0023fa2360340a156b7fa036585904a5de0784f803a82a5f042cdaca196698c1", size = 280379, upload-time = "2026-05-13T14:52:49.277Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/f8/8d954ce0f4cb1890810b655b4133d5dd1ef0137a438cabeb87ddb7b450d2/vapoursynth_eedi3vk2-1.0.tar.gz", hash = "sha256:8452b7a07ba94102fa89aa276eb344199f3f54134ad99bc8cf6b86ca743d7e02", size = 47944, upload-time = "2026-07-11T08:13:07.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/1e/a2c39fd4f3618baf5c683b4a2b58eed6dbc06cd7541757e7fd59216fefbc/vapoursynth_eedi3-10.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:5a4086aa40184b4abe85080b0b1e74f30d626721c3d8fbed5679abc973a924ef", size = 89353, upload-time = "2026-05-13T14:52:38.393Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7a/5f7ad99d9086d835d1f81aa7db9dd0eabb761484069d329f8c6060dcb6b4/vapoursynth_eedi3-10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8c2f3ba76e312ccc434c443a7ea1147effc78cbd4762ec3edd86c58c7da50896", size = 43333, upload-time = "2026-05-13T14:52:39.815Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/22/35db73a6a57375b8127b4594b4321a02fa84aca484dab3902c284ff988ea/vapoursynth_eedi3-10.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f446137944538395a7b1bf292ec64aaaea658f44abbac64adf2516d4454347b7", size = 202768, upload-time = "2026-05-13T14:52:41.052Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/7a/4e24efe01a8c828e13258284ff2f8928c80882806ec5e72ac111a1665ac8/vapoursynth_eedi3-10.0-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1f2e0a5fb7ae58ed88857835952259dd72fbf975eb03f9ce2407381e7e0426a", size = 255402, upload-time = "2026-05-13T14:52:42.605Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/d6/9ddaf38944463c4dc32ab3b39f6324e7ed8110bf618279cdee452c9282f8/vapoursynth_eedi3-10.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ce692f32b1df46f6ef6c0f873f6953125e9668d0e58ee17e01dd545e1d48a80f", size = 1033366, upload-time = "2026-05-13T14:52:44.066Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/49/a76e56e117bbf5fb10da3039f2478b6c48f0f64f73450f25278aae69ce4e/vapoursynth_eedi3-10.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9a6dedc4c34bd707407925e97d81e814409492a40210c0415185f1c11671a8c0", size = 1125741, upload-time = "2026-05-13T14:52:45.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9d/e4c27079e97008953fc79fccaccb2ca348edf9b158bee43aed9c5493ab5d/vapoursynth_eedi3-10.0-py3-none-win_amd64.whl", hash = "sha256:b509f489badb3b5f10d95c9a8754a35b502a9de82b47f3521bfb6a1a3b2f6eb7", size = 186822, upload-time = "2026-05-13T14:52:47.638Z" },
+    { url = "https://files.pythonhosted.org/packages/96/de/cb72fb80cbc4b1bc37c2da7319a57abd57cdea5638bc6ce4de57b81bb6c7/vapoursynth_eedi3vk2-1.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:7ad8c2d205f7d0f4932fb28b094b0dd3993cd5d3228968e35ed28b47f2bf822f", size = 223050, upload-time = "2026-07-11T08:12:56.703Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2c/a3618190b6ab47bf5e2d0a345820b098c77b4749955504e96e8eaa831d4c/vapoursynth_eedi3vk2-1.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c864731788dd2395a76614d1e2cbc6e2c7fbcf77b4a13d272768db1344f21d3f", size = 220251, upload-time = "2026-07-11T08:12:58.348Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/09/f3d765549d4663cd4245369628f73c7514afd16fdada8f9f662642d83dc0/vapoursynth_eedi3vk2-1.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:2ece8f3749ce3d56282829cc8b2d1e16c3a68317ae0c29b6133b8ada8868fa63", size = 230273, upload-time = "2026-07-11T08:12:59.776Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/353d4c03f62d742763becd12f3121526c16a1dac1db74c6b88fde3d5c7bc/vapoursynth_eedi3vk2-1.0-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:94bdb1ead46b6125fc8908a67268039a1980935655f1ef34c804002d657211ed", size = 236609, upload-time = "2026-07-11T08:13:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/c15d8178f7e6852c6f9dba14ca97322233ba4f8d047f3e851f9fa6ff467a/vapoursynth_eedi3vk2-1.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76ca6800386747d3370eaff2652e06a5f7554888be07d908804df2bb36eda5b7", size = 1211405, upload-time = "2026-07-11T08:13:03.097Z" },
+    { url = "https://files.pythonhosted.org/packages/32/22/1c51cf256fe219442853d099867f5e28c731e64f0fb319857c31b081a934/vapoursynth_eedi3vk2-1.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:235abcf51eaa4424374c9015323a8eb96498e1c7ba48c70d00893e6fadf44b16", size = 1269051, upload-time = "2026-07-11T08:13:04.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/2e/f958c8ef9f2df8069fcc9db9a56afcc9f1d663762e92744b52adba48a202/vapoursynth_eedi3vk2-1.0-py3-none-win_amd64.whl", hash = "sha256:2f3108942a01c0be7a439554898a7aa162024c1567a71d25b9ac2843fd3fb06c", size = 330802, upload-time = "2026-07-11T08:13:06.213Z" },
 ]
 
 [[package]]
@@ -2842,7 +2842,6 @@ aa = [
     { name = "vapoursynth-descale" },
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-edgemasks" },
-    { name = "vapoursynth-eedi3" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-hysteresis" },
     { name = "vapoursynth-lsmas" },
@@ -2858,6 +2857,7 @@ aa = [
 amd = [
     { name = "dfttest2", extra = ["hipfft", "hiprtc"] },
     { name = "vapoursynth-bm3dhip" },
+    { name = "vapoursynth-eedi3vk2" },
     { name = "vapoursynth-mlrt-migx", marker = "sys_platform == 'linux'" },
     { name = "vapoursynth-mlrt-ncnn" },
     { name = "vapoursynth-mlrt-ort" },
@@ -2890,7 +2890,6 @@ deband = [
     { name = "vapoursynth-descale" },
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-edgemasks" },
-    { name = "vapoursynth-eedi3" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-fmtconv" },
     { name = "vapoursynth-hysteresis" },
@@ -2932,7 +2931,6 @@ dehalo = [
     { name = "vapoursynth-descale" },
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-edgemasks" },
-    { name = "vapoursynth-eedi3" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-fmtconv" },
     { name = "vapoursynth-hysteresis" },
@@ -2974,7 +2972,6 @@ deinterlace = [
     { name = "vapoursynth-dmetrics" },
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-edgemasks" },
-    { name = "vapoursynth-eedi3" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-fmtconv" },
     { name = "vapoursynth-hysteresis" },
@@ -3016,7 +3013,6 @@ denoise = [
     { name = "vapoursynth-descale" },
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-edgemasks" },
-    { name = "vapoursynth-eedi3" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-fmtconv" },
     { name = "vapoursynth-hysteresis" },
@@ -3058,7 +3054,6 @@ full = [
     { name = "vapoursynth-dmetrics" },
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-edgemasks" },
-    { name = "vapoursynth-eedi3" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-fmtconv" },
     { name = "vapoursynth-hysteresis" },
@@ -3078,7 +3073,6 @@ full = [
     { name = "vsnoise" },
 ]
 gpu = [
-    { name = "vapoursynth-mlrt-ncnn" },
     { name = "vapoursynth-mlrt-ort" },
 ]
 kernels = [
@@ -3116,6 +3110,8 @@ nvidia = [
     { name = "tensorrt-rtx-cu13-bindings", version = "1.5.0.114", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
     { name = "vapoursynth-bilateralgpu" },
     { name = "vapoursynth-bm3dcuda" },
+    { name = "vapoursynth-eedi3vk2" },
+    { name = "vapoursynth-mlrt-ncnn" },
     { name = "vapoursynth-mlrt-ort-cuda" },
     { name = "vapoursynth-mlrt-trt" },
     { name = "vapoursynth-mlrt-trt-rtx" },
@@ -3160,6 +3156,10 @@ source = [
     { name = "vapoursynth-dvdsrc2" },
     { name = "vapoursynth-ffms2" },
     { name = "vapoursynth-lsmas" },
+]
+vulkan = [
+    { name = "vapoursynth-eedi3vk2" },
+    { name = "vapoursynth-mlrt-ncnn" },
 ]
 
 [package.dev-dependencies]
@@ -3377,12 +3377,9 @@ requires-dist = [
     { name = "vapoursynth-edgemasks", marker = "extra == 'full'", specifier = ">=4.0" },
     { name = "vapoursynth-edgemasks", marker = "extra == 'mask'", specifier = ">=4.0" },
     { name = "vapoursynth-edgemasks", marker = "extra == 'scale'", specifier = ">=4.0" },
-    { name = "vapoursynth-eedi3", marker = "extra == 'aa'", specifier = ">=9.0" },
-    { name = "vapoursynth-eedi3", marker = "extra == 'deband'", specifier = ">=9.0" },
-    { name = "vapoursynth-eedi3", marker = "extra == 'dehalo'", specifier = ">=9.0" },
-    { name = "vapoursynth-eedi3", marker = "extra == 'deinterlace'", specifier = ">=9.0" },
-    { name = "vapoursynth-eedi3", marker = "extra == 'denoise'", specifier = ">=9.0" },
-    { name = "vapoursynth-eedi3", marker = "extra == 'full'", specifier = ">=9.0" },
+    { name = "vapoursynth-eedi3vk2", marker = "extra == 'amd'", specifier = ">=1.0" },
+    { name = "vapoursynth-eedi3vk2", marker = "extra == 'nvidia'", specifier = ">=1.0" },
+    { name = "vapoursynth-eedi3vk2", marker = "extra == 'vulkan'", specifier = ">=1.0" },
     { name = "vapoursynth-ffms2", marker = "extra == 'aa'", specifier = ">=5.2.0", index = "https://jaded-encoding-thaumaturgy.github.io/vs-wheels/simple" },
     { name = "vapoursynth-ffms2", marker = "extra == 'deband'", specifier = ">=5.2.0", index = "https://jaded-encoding-thaumaturgy.github.io/vs-wheels/simple" },
     { name = "vapoursynth-ffms2", marker = "extra == 'dehalo'", specifier = ">=5.2.0", index = "https://jaded-encoding-thaumaturgy.github.io/vs-wheels/simple" },
@@ -3421,7 +3418,8 @@ requires-dist = [
     { name = "vapoursynth-manipmv", marker = "extra == 'full'", specifier = ">=1.3.0" },
     { name = "vapoursynth-mlrt-migx", marker = "sys_platform == 'linux' and extra == 'amd'", specifier = ">=15.16" },
     { name = "vapoursynth-mlrt-ncnn", marker = "extra == 'amd'", specifier = ">=15.16" },
-    { name = "vapoursynth-mlrt-ncnn", marker = "extra == 'gpu'", specifier = ">=15.16" },
+    { name = "vapoursynth-mlrt-ncnn", marker = "extra == 'nvidia'", specifier = ">=15.16" },
+    { name = "vapoursynth-mlrt-ncnn", marker = "extra == 'vulkan'", specifier = ">=15.16" },
     { name = "vapoursynth-mlrt-ort", marker = "extra == 'amd'", specifier = ">=15.16" },
     { name = "vapoursynth-mlrt-ort", marker = "extra == 'gpu'", specifier = ">=15.16" },
     { name = "vapoursynth-mlrt-ort-cuda", marker = "extra == 'nvidia'", specifier = ">=15.16.2" },
@@ -3508,7 +3506,7 @@ requires-dist = [
     { name = "vsnoise", marker = "extra == 'deband'", specifier = ">=1.2" },
     { name = "vsnoise", marker = "extra == 'full'", specifier = ">=1.2" },
 ]
-provides-extras = ["aa", "amd", "basic", "cl", "deband", "dehalo", "deinterlace", "denoise", "expr", "full", "gpu", "kernels", "mask", "nvidia", "rg", "scale", "source"]
+provides-extras = ["aa", "amd", "basic", "cl", "deband", "dehalo", "deinterlace", "denoise", "expr", "full", "gpu", "kernels", "mask", "nvidia", "rg", "scale", "source", "vulkan"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/vsaa/deinterlacers.py
+++ b/vsaa/deinterlacers.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections import UserDict
-from collections.abc import Mapping, Sequence
+from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass, replace
 from enum import IntFlag, auto
 from fractions import Fraction
-from typing import TYPE_CHECKING, Any, Protocol, Self, cast, runtime_checkable
+from operator import attrgetter
+from typing import TYPE_CHECKING, Any, Never, Protocol, Self, cast, runtime_checkable
 
-from jetpytools import CustomNotImplementedError, CustomValueError, fallback, normalize_seq
+from jetpytools import MISSING, CustomNotImplementedError, CustomStrEnum, CustomValueError, fallback, normalize_seq
 
 from vsjetpack import TypeVar
 from vskernels import (
@@ -230,7 +232,11 @@ class AntiAliaser(Deinterlacer, ABC):
 
         return clip
 
-    def transpose(self, clip: vs.VideoNode, **kwargs: Any) -> tuple[vs.VideoNode, Mapping[str, vs.VideoNode | None]]:
+    def transpose(
+        self,
+        clip: vs.VideoNode,
+        **kwargs: Any,
+    ) -> tuple[vs.VideoNode, MutableMapping[str, vs.VideoNode | None]]:
         """
         Transpose the input clip by swapping its horizontal and vertical axes.
 
@@ -488,6 +494,92 @@ class EEDI3(SuperSampler):
     Enhanced Edge Directed Interpolation (3rd gen.)
     """
 
+    class Backend(CustomStrEnum):
+        """Enum representing available backends on which to run the plugin."""
+
+        CPU = "vszip"
+        """Pure CPU implementation"""
+
+        OPENCL = "vszipcl"
+        """An OpenCL device"""
+
+        VULKAN = "eedi3vk2"
+        """A Vulkan device"""
+
+        @property
+        def supports_mclip(self) -> bool:
+            """Whether the backend supports mclip."""
+            return "mclip" in getattr(core, self.value).EEDI3.__signature__.parameters
+
+        @property
+        def supports_h(self) -> bool:
+            """Whether the backend supports columns interpolating."""
+            return hasattr(getattr(core, self.value), "EEDI3H")
+
+        @property
+        def should_h(self) -> bool:
+            """Whether the backend should run columns interpolating."""
+            return self.supports_h and self != EEDI3.Backend.CPU
+
+        def EEDI3(  # noqa: N802
+            self,
+            clip: vs.VideoNode,
+            field: int,
+            *args: Any,
+            sclip: vs.VideoNode | None = None,
+            mclip: vs.VideoNode | None = None,
+            **kwargs: Any,
+        ) -> vs.VideoNode:
+            """Applies the EEDI3 filter using the plugin associated with the selected backend."""
+            if self.supports_mclip:
+                kwargs.update(sclip=sclip, mclip=mclip)
+            else:
+                kwargs.update(sclip=sclip)
+
+            return getattr(core, self.value).EEDI3(clip, field, *args, **kwargs)
+
+        def EEDI3H(  # noqa: N802
+            self,
+            clip: vs.VideoNode,
+            field: int,
+            *args: Any,
+            sclip: vs.VideoNode | None = None,
+            mclip: vs.VideoNode | None = None,
+            **kwargs: Any,
+        ) -> vs.VideoNode:
+            """Applies the EEDI3H filter using the plugin associated with the selected backend."""
+            if self.should_h:
+                attr = "EEDI3H"
+                tclips = {"sclip": sclip, "mclip": mclip}
+            else:
+                attr = "EEDI3"
+                clip, tclips = self.transpose(clip, sclip=sclip, mclip=mclip, **kwargs)
+
+            if self.supports_mclip:
+                kwargs.update(sclip=tclips["sclip"], mclip=tclips["mclip"])
+            else:
+                kwargs.update(sclip=tclips["sclip"])
+
+            result = attrgetter(f"{self.value}.{attr}")(core)(clip, field, *args, **kwargs)
+            return result if self.should_h else result.std.Transpose()
+
+        @staticmethod
+        def transpose(
+            clip: vs.VideoNode,
+            *,
+            sclip: vs.VideoNode | None = None,
+            mclip: vs.VideoNode | None = None,
+            **kwargs: Any,
+        ) -> tuple[vs.VideoNode, MutableMapping[str, vs.VideoNode | None]]:
+            """Transpose the input clip by swapping its horizontal and vertical axes."""
+            if isinstance(sclip, vs.VideoNode):
+                sclip = sclip.std.Transpose()
+
+            if isinstance(mclip, vs.VideoNode):
+                mclip = mclip.std.Transpose()
+
+            return clip.std.Transpose(), kwargs | {"sclip": sclip, "mclip": mclip}
+
     alpha: float = 0.2
     """
     Controls the weight given to connecting similar neighborhoods.
@@ -533,19 +625,18 @@ class EEDI3(SuperSampler):
     but this can also increase the chance of artifacts and slow down processing.
     """
 
-    ucubic: bool = True
+    hp: bool = False
     """
-    Determines the type of interpolation used.
-    - When `ucubic=True`, cubic 4-point interpolation is applied.
-    - When `ucubic=False`, 2-point linear interpolation is used.
+    Determines the type of search steps:
+    - When hp=True, it uses half-pel search steps.
+    - When hp=False, it uses full-pel search steps.
     """
 
-    cost3: bool = True
-    """
-    Defines the neighborhood cost function used to measure similarity.
-    - When `cost3=True`, a 3-neighborhood cost function is used.
-    - When `cost3=False`, a 1-neighborhood cost function is applied.
-    """
+    ucubic: Never = cast(Never, MISSING)
+    """Unused deprecated parameter."""
+
+    cost3: Never = cast(Never, MISSING)
+    """Unused deprecated parameter."""
 
     vcheck: int = 2
     """
@@ -579,6 +670,13 @@ class EEDI3(SuperSampler):
     or bicubic methods instead.
     The primary purpose of the mask is to reduce computational overhead
     by limiting edge-directed interpolation to certain pixels.
+
+    Only the VULKAN and CPU backends supports it.
+    """
+
+    backend: Backend = Backend.CPU
+    """
+    Set the backend to use for processing.
     """
 
     @Scaler.cachedproperty
@@ -627,7 +725,7 @@ class EEDI3(SuperSampler):
     def get_deint_args(self, **kwargs: Any) -> dict[str, Any]:
         vthresh = (None, None, None) if self.vthresh is None else self.vthresh
 
-        return {
+        kwargs = {
             "alpha": self.alpha,
             "beta": self.beta,
             "gamma": self.gamma,
@@ -643,26 +741,57 @@ class EEDI3(SuperSampler):
             "mclip": self.mclip,
         } | kwargs
 
+        # TODO: Remove that
+        for k, v in ((k, v) for k, v in kwargs.copy().items() if k in ["ucubic", "cost3"]):
+            if v is not cast(Never, MISSING):
+                warnings.warn(f"'{k}' argument has been removed and is deprecated.", RuntimeWarning)
+            del kwargs[k]
+
+        return kwargs
+
     def antialias(
-        self, clip: vs.VideoNode, direction: AntiAliaser.AADirection = AntiAliaser.AADirection.BOTH, **kwargs: Any
+        self,
+        clip: vs.VideoNode,
+        direction: AntiAliaser.AADirection = AntiAliaser.AADirection.BOTH,
+        **kwargs: Any,
     ) -> vs.VideoNode:
         kwargs = self.get_deint_args(**kwargs)
 
-        sclip, mclip = kwargs.pop("sclip"), kwargs.pop("mclip")
+        sclip, mclip = kwargs.pop("sclip", None), kwargs.pop("mclip", None)
 
         if isinstance(sclip, Deinterlacer):
             raise CustomValueError("sclip must be a callable or VideoNode", self.antialias)
 
-        if sclip and self.double_rate:
+        if sclip:
             if isinstance(sclip, VSFunctionNoArgs):
                 sclip = sclip(clip)
 
-            sclip = core.std.Interleave([sclip, sclip])
+            if self.double_rate:
+                sclip = core.std.Interleave([sclip, sclip])
 
         if isinstance(mclip, VSFunctionNoArgs):
             mclip = mclip(clip)
 
-        return super().antialias(clip, direction, sclip=sclip, mclip=mclip, **kwargs)
+        tff = fallback(kwargs.pop("tff", self.tff), True)
+
+        for y in sorted(self.AADirection, key=lambda x: x.value, reverse=self.transpose_first):
+            if direction in (y, self.AADirection.BOTH):
+                horizontal = y == self.AADirection.HORIZONTAL
+                clip = self._interpolate(
+                    clip,
+                    tff,
+                    self.double_rate,
+                    False,
+                    horizontal=horizontal,
+                    sclip=sclip,
+                    mclip=mclip,
+                    **kwargs,
+                )
+
+                if self.double_rate:
+                    clip = core.std.Merge(clip[::2], clip[1::2])
+
+        return clip
 
     def transpose(
         self,
@@ -671,8 +800,7 @@ class EEDI3(SuperSampler):
         sclip: vs.VideoNode | None = None,
         mclip: vs.VideoNode | None = None,
         **kwargs: Any,
-    ) -> tuple[vs.VideoNode, Mapping[str, vs.VideoNode | None]]:
-        # At this point, sclip and mclip can only be a VideoNode or None
+    ) -> tuple[vs.VideoNode, MutableMapping[str, vs.VideoNode | None]]:
         if isinstance(sclip, vs.VideoNode):
             sclip = sclip.std.Transpose()
 
@@ -698,10 +826,24 @@ class EEDI3(SuperSampler):
 
     @property
     def _deinterlacer_function(self) -> VSFunctionAllArgs:
-        return core.lazy.eedi3m.EEDI3
+        return self.backend.EEDI3
 
-    def _interpolate(self, clip: vs.VideoNode, tff: bool, double_rate: bool, dh: bool, **kwargs: Any) -> vs.VideoNode:
-        return self._deinterlacer_function(clip, tff + double_rate * 2, dh, **self.get_deint_args(**kwargs))
+    @property
+    def _deinterlacer_function_h(self) -> VSFunctionAllArgs:
+        return self.backend.EEDI3H
+
+    def _interpolate(
+        self,
+        clip: vs.VideoNode,
+        tff: bool,
+        double_rate: bool,
+        dh: bool,
+        *,
+        horizontal: bool = False,
+        **kwargs: Any,
+    ) -> vs.VideoNode:
+        func = self._deinterlacer_function_h if horizontal else self._deinterlacer_function
+        return func(clip, tff + double_rate * 2, dh, **self.get_deint_args(**kwargs))
 
 
 @dataclass

--- a/vsaa/funcs.py
+++ b/vsaa/funcs.py
@@ -204,12 +204,26 @@ def based_aa(
     ss = supersampler.scale(ss_clip, aaw, aah)
 
     if not antialiaser:
-        antialiaser = EEDI3(alpha=0.125, beta=0.25, gamma=40, vthresh=(12, 24, 4), sclip=ss)
+        antialiaser = EEDI3(
+            alpha=0.125,
+            beta=0.25,
+            gamma=40,
+            vthresh=(12, 24, 4),
+            sclip=ss,
+            backend=aa_kwargs.pop("backend", EEDI3.__dataclass_fields__["backend"].default),
+        )
 
-    # Only uses mclip if `use_mclip` is True,
-    # if mclip isn't in aa_kwargs
-    # and antialiaser is an instance of EEDI3
-    if aa_kwargs.pop("use_mclip", True) and "mclip" not in aa_kwargs and isinstance(antialiaser, EEDI3):
+    # Only uses mclip if
+    # - `use_mclip` is True,
+    # - mclip isn't in aa_kwargs
+    # - antialiaser is an instance of EEDI3
+    # - backend supports mclip
+    if (
+        aa_kwargs.pop("use_mclip", True)
+        and "mclip" not in aa_kwargs
+        and isinstance(antialiaser, EEDI3)
+        and antialiaser.backend.supports_mclip
+    ):
         mclip = None
 
         if mask:


### PR DESCRIPTION
- Split the `gpu` extra into `gpu` and `vulkan` extras
- Add `eedi3vk2`
- Remove `eedi3m`
- `vsjetpack[nvidia]` now also depends on `vsjetpack[vulkan]`
- `vsjetpack[amd]` now also depends on `vsjetpack[vulkan]`
- `ucubic` and `cost3` are now unused deprecated parameters.
- New `backend` parameter