### PR TITLE
onnx: implement global cache fallback

### DIFF
--- a/tests/vsscale/test_settings.py
+++ b/tests/vsscale/test_settings.py
@@ -1,0 +1,238 @@
+from pathlib import Path
+from typing import Self
+
+import pytest
+from jetpytools import FileNotExistsError
+
+from vsscale.mlrt.settings import (
+    get_artifact_path,
+    get_artifacts_folder,
+    get_cache,
+    get_global_cache,
+    get_local_cache,
+    get_model_folder,
+    get_model_path,
+    get_onnx_folder,
+    get_toml_config,
+    is_fallback_enabled,
+    is_global_true,
+)
+
+
+class DummyFile:
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None: ...
+
+
+def test_is_global_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Global True
+    with monkeypatch.context() as m:
+        m.setenv("VSSCALE_GLOBAL", "true")
+        assert is_global_true("onnx") is True
+
+    # Specific True
+    with monkeypatch.context() as m:
+        m.setenv("VSSCALE_ONNX_GLOBAL", "1")
+        assert is_global_true("onnx") is True
+
+    # Global False
+    with monkeypatch.context() as m:
+        m.setenv("VSSCALE_GLOBAL", "false")
+        assert is_global_true("onnx") is False
+
+    # Empty env
+    assert is_global_true("onnx") is False
+
+
+def test_is_fallback_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Env Vars
+    with monkeypatch.context() as m:
+        m.setenv("VSSCALE_FALLBACK", "false")
+        assert is_fallback_enabled("onnx") is False
+
+    with monkeypatch.context() as m:
+        m.setenv("VSSCALE_ONNX_FALLBACK", "0")
+        assert is_fallback_enabled("onnx") is False
+
+    with monkeypatch.context() as m:
+        m.setenv("VSSCALE_FALLBACK", "true")
+        assert is_fallback_enabled("onnx") is True
+
+    # TOML configs
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {"fallback": False})
+        assert is_fallback_enabled("onnx") is False
+
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {"fallback": True})
+        assert is_fallback_enabled("onnx") is True
+
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {"onnx": {"fallback": False}})
+        assert is_fallback_enabled("onnx") is False
+
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {"onnx": {"fallback": True}})
+        assert is_fallback_enabled("onnx") is True
+
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {})
+        assert is_fallback_enabled("onnx") is True
+
+
+def test_get_model_folder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    onnx_dir = tmp_path / "onnx"
+    provider_dir = onnx_dir / "artcnn"
+    provider_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("vsscale.mlrt.settings.get_onnx_folder", lambda **kwargs: onnx_dir)
+    with pytest.raises(FileNotExistsError):
+        get_model_folder("artcnn")
+
+    v1 = provider_dir / "v1.0.0"
+    v2 = provider_dir / "v2.0.0"
+    v1.mkdir()
+    v2.mkdir()
+
+    assert get_model_folder("artcnn") == v2
+    assert get_model_folder("artcnn", "v1.0.0") == v1
+
+    with pytest.raises(FileNotExistsError):
+        get_model_folder("artcnn", "v3.0.0")
+
+
+def test_get_model_path_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    local_dir = tmp_path / "local"
+    global_dir = tmp_path / "global"
+
+    local_provider = local_dir / "artcnn" / "v1.0.0"
+    global_provider = global_dir / "artcnn" / "v2.0.0"
+
+    local_provider.mkdir(parents=True)
+    global_provider.mkdir(parents=True)
+
+    global_model = global_provider / "ArtCNN_R8F64.onnx"
+    global_model.touch()
+
+    monkeypatch.setattr(
+        "vsscale.mlrt.settings.get_onnx_folder",
+        lambda global_=False: global_dir if global_ else local_dir,
+    )
+
+    # Fallback enabled (default): should find the global model file (since local doesn't exist)
+    path = get_model_path("artcnn", "ArtCNN_R8F64")
+    assert path == global_model
+
+    # Local exists: should find the local model file first
+    local_model = local_provider / "ArtCNN_R8F64.onnx"
+    local_model.touch()
+    path = get_model_path("artcnn", "ArtCNN_R8F64")
+    assert path == local_model
+    local_model.unlink()
+
+    # Fallback disabled: should return the default local path (which doesn't exist)
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.is_fallback_enabled", lambda thing: False)
+        path = get_model_path("artcnn", "ArtCNN_R8F64")
+        assert path == local_provider / "ArtCNN_R8F64.onnx"
+        assert not path.exists()
+
+
+def test_get_artifact_path_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    local_dir = tmp_path / "local_art"
+    global_dir = tmp_path / "global_art"
+
+    local_dir.mkdir()
+    global_dir.mkdir()
+
+    global_file = global_dir / "test.engine"
+    global_file.touch()
+
+    monkeypatch.setattr(
+        "vsscale.mlrt.settings.get_artifacts_folder",
+        lambda global_=False: global_dir if global_ else local_dir,
+    )
+
+    # Fallback enabled (default) and fallback requested: finds global engine
+    path = get_artifact_path("test.engine", fallback=True)
+    assert path == global_file
+
+    # Local exists: finds local engine first
+    local_file = local_dir / "test.engine"
+    local_file.touch()
+    path = get_artifact_path("test.engine", fallback=True)
+    assert path == local_file
+    local_file.unlink()
+
+    # Fallback parameter false: returns local path (which doesn't exist)
+    path = get_artifact_path("test.engine", fallback=False)
+    assert path == local_dir / "test.engine"
+
+    # Fallback disabled in config: returns local path
+    with monkeypatch.context() as m:
+        m.setattr("vsscale.mlrt.settings.is_fallback_enabled", lambda thing: False)
+        path = get_artifact_path("test.engine", fallback=True)
+        assert path == local_dir / "test.engine"
+
+
+def test_get_toml_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Test when no config file exists
+    with monkeypatch.context() as m:
+        m.setattr(Path, "exists", lambda self: False)
+        assert get_toml_config() == {}
+
+    # Test when vsjet.toml exists
+    with monkeypatch.context() as m:
+        m.setattr(Path, "exists", lambda self: self.name == "vsjet.toml")
+        m.setattr(Path, "open", lambda self, *args, **kwargs: DummyFile())
+        m.setattr("tomllib.load", lambda f: {"vsscale": {"global": True}})
+
+        assert get_toml_config() == {"global": True}
+
+
+def test_cache_directories(monkeypatch: pytest.MonkeyPatch) -> None:
+    global_cache = get_global_cache()
+    local_cache = get_local_cache()
+
+    assert isinstance(global_cache, Path)
+    assert isinstance(local_cache, Path)
+
+    monkeypatch.setattr("vsscale.mlrt.settings.get_cache", lambda thing, global_=False: Path("/dummy"))
+    assert get_onnx_folder() == Path("/dummy/onnx")
+    assert get_artifacts_folder() == Path("/dummy/artifact")
+
+
+def test_get_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_cache.cache_clear()
+
+    dummy_global = Path("/dummy_global")
+    dummy_local = Path("/dummy_local")
+
+    monkeypatch.setattr("vsscale.mlrt.settings.get_global_cache", lambda: dummy_global)
+    monkeypatch.setattr("vsscale.mlrt.settings.get_local_cache", lambda: dummy_local)
+
+    # Test global_=True parameter
+    get_cache.cache_clear()
+    assert get_cache("onnx", global_=True) == dummy_global
+
+    # Test is_global_true is True
+    with monkeypatch.context() as m:
+        get_cache.cache_clear()
+        m.setattr("vsscale.mlrt.settings.is_global_true", lambda thing: True)
+        assert get_cache("onnx") == dummy_global
+
+    # Test get_toml_config specifies global=True
+    with monkeypatch.context() as m:
+        get_cache.cache_clear()
+        m.setattr("vsscale.mlrt.settings.is_global_true", lambda thing: False)
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {"global": True})
+        assert get_cache("onnx") == dummy_global
+
+    # Test fallback to local cache
+    with monkeypatch.context() as m:
+        get_cache.cache_clear()
+        m.setattr("vsscale.mlrt.settings.is_global_true", lambda thing: False)
+        m.setattr("vsscale.mlrt.settings.get_toml_config", lambda: {})
+        assert get_cache("onnx") == dummy_local

--- a/vsscale/mlrt/__init__.py
+++ b/vsscale/mlrt/__init__.py
@@ -47,6 +47,10 @@ By default, files are managed locally within the package storage `.vsjet` folder
 Add the `--global` flag to target the platform-specific user cache directory
 (e.g., `AppData\\Local\\vsjet\\vsscale\\Cache` on Windows).
 
+If models or compiled engine artifacts are not found in the local cache,
+the library will automatically fall back to checking the global cache before raising an error or downloading.
+This fallback behavior can be customized or disabled (see Configuration section).
+
 ---
 
 ## Configuration (TOML & Environment Variables)
@@ -60,12 +64,14 @@ The library parses configurations from `vsjet.toml` or `pyproject.toml` in the w
   ```toml
   [vsscale]
   global = true       # Use the global cache folder by default
+  fallback = false    # Disable global cache fallback (default is true)
   ```
 
 - **pyproject.toml**:
   ```toml
   [tool.vsscale]
   global = true
+  fallback = false
 
   [tool.vsscale.onnx.download]
   # This tells the CLI to automatically download the latest release
@@ -89,6 +95,8 @@ The library parses configurations from `vsjet.toml` or `pyproject.toml` in the w
 #### Environment Variables:
 - `VSSCALE_GLOBAL` / `VSSCALE_ONNX_GLOBAL` / `VSSCALE_ARTIFACT_GLOBAL`:
   Set to `true` to force global storage.
+- `VSSCALE_FALLBACK` / `VSSCALE_ONNX_FALLBACK` / `VSSCALE_ARTIFACT_FALLBACK`:
+  Set to `false` to disable the automatic global cache fallback.
 - `VSSCALE_LATEST` / `VSSCALE_ONNX_DOWNLOAD_LATEST`:
   Set to `true` to default to downloading latest releases.
 
@@ -153,18 +161,22 @@ You can explicitly instantiate specific backends and configure their execution d
 
 from .backend import Backend
 from .settings import (
+    get_artifact_path,
     get_artifacts_folder,
     get_global_cache,
     get_local_cache,
     get_model_folder,
-    get_provider_folder,
+    get_model_path,
+    get_onnx_folder,
 )
 
 __all__ = [
     "Backend",
+    "get_artifact_path",
     "get_artifacts_folder",
     "get_global_cache",
     "get_local_cache",
     "get_model_folder",
-    "get_provider_folder",
+    "get_model_path",
+    "get_onnx_folder",
 ]

--- a/vsscale/mlrt/backend/migx.py
+++ b/vsscale/mlrt/backend/migx.py
@@ -13,7 +13,7 @@ from jetpytools import CustomRuntimeError, CustomValueError, copy_signature, to_
 
 from vstools import UnsupportedSampleTypeError, core, vs
 
-from ..settings import get_artifacts_folder
+from ..settings import get_artifact_path
 from .base import BackendAutoConvertFloat
 
 type Shape = tuple[int, int]
@@ -145,13 +145,13 @@ class MIGX(BackendAutoConvertFloat):
         else:
             migraph_driver = shutil.which("migraphx-driver") or "migraphx-driver"
 
-        dirname = get_artifacts_folder()
-        dirname.mkdir(parents=True, exist_ok=True)
         identity = self.get_identity(network_path, tilesize)
-        program_path = dirname / f"{identity}.mxr"
+        program_path = get_artifact_path(f"{identity}.mxr", fallback=not self.force_rebuild)
 
         if not self.force_rebuild and program_path.is_file() and program_path.stat().st_size >= 1024:
             return program_path
+
+        program_path.parent.mkdir(parents=True, exist_ok=True)
 
         command: list[Any] = [
             migraph_driver,

--- a/vsscale/mlrt/backend/trt.py
+++ b/vsscale/mlrt/backend/trt.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 from vstools import UnsupportedSampleTypeError, core, depth, vs
 
-from ..settings import get_artifacts_folder, get_provider_folder
+from ..settings import get_artifact_path, get_onnx_folder
 from .base import Backend
 
 type Shape = tuple[int, int]
@@ -241,13 +241,13 @@ class TRT(Backend):
         elif self.bf16:
             network_path = self._convert_onnx_bf16(network_path)
 
-        dirname = get_artifacts_folder()
-        dirname.mkdir(parents=True, exist_ok=True)
         identity = self.get_identity(network_path, channels, tilesize)
-        engine_path = dirname / f"{identity}.engine"
+        engine_path = get_artifact_path(f"{identity}.engine", fallback=not self.force_rebuild)
 
         if not self.force_rebuild and engine_path.is_file() and engine_path.stat().st_size >= 1024:
             return engine_path
+
+        engine_path.parent.mkdir(parents=True, exist_ok=True)
 
         self.build(
             network_path=network_path,
@@ -409,10 +409,10 @@ class TRT(Backend):
 
         network = network_path.read_bytes()
 
-        get_provider_folder().mkdir(parents=True, exist_ok=True)
+        get_onnx_folder().mkdir(parents=True, exist_ok=True)
         suffix = "fp16" if not self.fp16_blacklist_ops else f"fp16_block_{'_'.join(self.fp16_blacklist_ops)}"
         checksum = zlib.crc32(network)
-        fp16_path = get_provider_folder() / f"{network_path.stem}_{checksum:x}_{suffix}.onnx"
+        fp16_path = get_onnx_folder() / f"{network_path.stem}_{checksum:x}_{suffix}.onnx"
 
         if fp16_path.is_file() and fp16_path.stat().st_size >= 1024:
             return fp16_path
@@ -448,9 +448,9 @@ class TRT(Backend):
 
         network = network_path.read_bytes()
 
-        get_provider_folder().mkdir(parents=True, exist_ok=True)
+        get_onnx_folder().mkdir(parents=True, exist_ok=True)
         checksum = zlib.crc32(network)
-        bf16_path = get_provider_folder() / f"{network_path.stem}_{checksum:x}_bf16_io.onnx"
+        bf16_path = get_onnx_folder() / f"{network_path.stem}_{checksum:x}_bf16_io.onnx"
 
         if bf16_path.is_file() and bf16_path.stat().st_size >= 1024:
             return bf16_path

--- a/vsscale/mlrt/cli.py
+++ b/vsscale/mlrt/cli.py
@@ -22,7 +22,7 @@ from rich.progress import BarColumn, DownloadColumn, Progress, TextColumn, Trans
 from vsjetpack import __version__
 
 from .feeds import Asset, Feed, Release
-from .settings import TOML_CONFIG, TOML_KEYS, get_artifacts_folder, get_provider_folder
+from .settings import TOML_CONFIG, TOML_KEYS, get_artifacts_folder, get_onnx_folder
 
 MAX_CONCURRENCY = os.cpu_count() or 4
 
@@ -167,7 +167,7 @@ def show(
 
     match cmd:
         case "onnx":
-            folder = get_provider_folder(global_=global_)
+            folder = get_onnx_folder(global_=global_)
             ext = [".onnx"]
         case "artifact":
             folder = get_artifacts_folder(global_=global_)
@@ -199,7 +199,7 @@ def clear(
 
     match cmd:
         case "onnx":
-            folder = get_provider_folder(global_=global_)
+            folder = get_onnx_folder(global_=global_)
         case "artifact":
             folder = get_artifacts_folder(global_=global_)
         case _:
@@ -300,7 +300,7 @@ async def _select_assets(release: Release) -> list[Asset]:
 
 
 async def _download_assets(feed: Feed, release: Release, assets: Sequence[Asset], *, global_: bool = False) -> None:
-    dest_folder = anyio.Path(get_provider_folder(global_=global_) / feed.display_name.lower() / release.tag)
+    dest_folder = anyio.Path(get_onnx_folder(global_=global_) / feed.display_name.lower() / release.tag)
 
     console.print(f"[bold]Downloading to:[/bold] [cyan]{dest_folder}[/cyan]")
 

--- a/vsscale/mlrt/settings.py
+++ b/vsscale/mlrt/settings.py
@@ -1,6 +1,8 @@
 import os
 import tomllib
+from contextlib import suppress
 from functools import cache
+from logging import getLogger
 from pathlib import Path
 from typing import Any
 
@@ -11,9 +13,12 @@ from vstools import PackageStorage
 APP_AUTHOR = "vsjet"
 APP_NAME = "vsscale"
 TRUTHY = frozenset({"1", "true", "yes", "on"})
+FALSY = frozenset({"0", "false", "no", "off"})
 ENV_KEYS = ("VSSCALE_GLOBAL", "VSSCALE_{}_GLOBAL")
 TOML_CONFIG = ("vsjet.toml", "pyproject.toml")
 TOML_KEYS: tuple[list[str], ...] = (["vsscale"], ["tool", "vsscale"])
+
+logger = getLogger(__name__)
 
 
 def get_toml_config() -> dict[str, Any]:
@@ -44,7 +49,7 @@ def get_local_cache() -> Path:
 
 @cache
 def get_cache(thing: str, *, global_: bool = False) -> Path:
-    if global_ or is_global_in_env(thing):
+    if global_ or is_global_true(thing):
         return get_global_cache()
 
     if get_toml_config().get("global", False):
@@ -54,16 +59,16 @@ def get_cache(thing: str, *, global_: bool = False) -> Path:
 
 
 @cache
-def get_provider_folder(*, global_: bool = False) -> Path:
+def get_onnx_folder(*, global_: bool = False) -> Path:
     r"""
     If `global_=True`:
-        - Linux: ~/.cache/vsscale/provider
-        - macOS: ~/Library/Caches/vsscale/provider
-        - Windows: ...\AppData\Local\vsjet\vsscale\Cache\provider
+        - Linux: ~/.cache/vsscale/onnx
+        - macOS: ~/Library/Caches/vsscale/onnx
+        - Windows: ...\AppData\Local\vsjet\vsscale\Cache\onnx
 
     Else returns a local `.vsjet` package storage.
     """
-    return get_cache("provider", global_=global_) / "provider"
+    return get_cache("onnx", global_=global_) / "onnx"
 
 
 @cache
@@ -79,12 +84,29 @@ def get_artifacts_folder(*, global_: bool = False) -> Path:
     return get_cache("artifact", global_=global_) / "artifact"
 
 
-def is_global_in_env(filetype: str) -> bool:
-    return any(env.lower() in TRUTHY for env in (os.getenv(k.format(filetype), "") for k in ENV_KEYS))
+def is_global_true(filetype: str) -> bool:
+    return any(env.lower() in TRUTHY for env in (os.getenv(k.format(filetype.upper()), "") for k in ENV_KEYS))
 
 
-def get_model_folder(provider: str, version: str | None = None) -> Path:
-    folder = get_provider_folder() / provider.lower()
+def is_fallback_enabled(thing: str) -> bool:
+    keys = ["VSSCALE_FALLBACK", f"VSSCALE_{thing.upper()}_FALLBACK"]
+
+    for k in keys:
+        if val := os.getenv(k, ""):
+            return val.lower() not in FALSY
+
+    config = get_toml_config()
+    if (val := config.get("fallback")) is not None:
+        return bool(val)
+
+    if isinstance(val := config.get(thing, {}), dict) and "fallback" in val:
+        return bool(val["fallback"])
+
+    return True
+
+
+def get_model_folder(provider: str, version: str | None = None, *, global_: bool = False) -> Path:
+    folder = get_onnx_folder(global_=global_) / provider.lower()
 
     if version is None:
         latest = sorted(folder.glob("*"), reverse=True)
@@ -100,3 +122,38 @@ def get_model_folder(provider: str, version: str | None = None) -> Path:
         raise FileNotExistsError("The folder doesn't exist", get_model_folder)
 
     return folder
+
+
+def get_model_path(provider: str, model_name: str, version: str | None = None) -> Path:
+    with suppress(FileNotExistsError):
+        if (path := get_model_folder(provider, version) / f"{model_name}.onnx").exists():
+            logger.info("Found model %s at %s", model_name, path)
+            return path
+
+    if is_fallback_enabled("onnx") and get_onnx_folder() != get_onnx_folder(global_=True):
+        with suppress(FileNotExistsError):
+            if (path := get_model_folder(provider, version, global_=True) / f"{model_name}.onnx").exists():
+                logger.info("Found model %s in global fallback %s", model_name, path)
+                return path
+
+    default_path = get_model_folder(provider, version) / f"{model_name}.onnx"
+    logger.info("Model %s not found. Returning default path: %s", model_name, default_path)
+    return default_path
+
+
+def get_artifact_path(filename: str, *, fallback: bool = True) -> Path:
+    dirname = get_artifacts_folder()
+    path = dirname / filename
+
+    if path.exists():
+        logger.info("Found artifact %s at %s", filename, path)
+        return path
+
+    if fallback and is_fallback_enabled("artifact") and dirname != (g_dirname := get_artifacts_folder(global_=True)):
+        g_path = g_dirname / filename
+        if g_path.exists():
+            logger.info("Found artifact %s in global fallback %s", filename, g_path)
+            return g_path
+
+    logger.info("Artifact %s not found. Returning default path: %s", filename, path)
+    return path

--- a/vsscale/onnx.py
+++ b/vsscale/onnx.py
@@ -8,6 +8,7 @@ import dataclasses
 import math
 import re
 from abc import ABC
+from contextlib import suppress
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, SupportsFloat
@@ -39,7 +40,7 @@ from vstools import (
 )
 
 from .generic import BaseGenericScaler
-from .mlrt import Backend, get_model_folder
+from .mlrt import Backend, get_model_path
 from .mlrt.backend.base import Backend as RealBackend
 from .mlrt.settings import get_toml_config
 
@@ -936,11 +937,11 @@ def _get_onnx_model(
     auto_download: bool | None = None,
     func: FuncExcept | None = None,
 ) -> Path:
-    try:
-        if (path := get_model_folder(provider) / f"{model_name}.onnx").exists():
+    with suppress(FileNotExistsError):
+        if (path := get_model_path(provider, model_name)).exists():
             return path
-    except FileNotExistsError:
-        logger.debug("%r does not exist", model_name)
+
+    logger.debug("%r does not exist", model_name)
 
     conf = get_toml_config()
     dconf = conf.get("onnx", {}).get("download", {})
@@ -957,8 +958,9 @@ def _get_onnx_model(
 
         app(["onnx", "download", user_provider or provider, "--latest"], console=console, result_action="return_value")
 
-        if (path := get_model_folder(provider) / f"{model_name}.onnx").exists():
-            return path
+        with suppress(FileNotExistsError):
+            if (path := get_model_path(provider, model_name)).exists():
+                return path
 
     raise CustomRuntimeError(
         f"The specified model {model_name} does not exist. "


### PR DESCRIPTION
Add a fallback mechanism that automatically checks the global cache if a model or artifact is not found in the local cache.

This behavior can be toggled via environment variables (`VSSCALE_FALLBACK`, `VSSCALE_ONNX_FALLBACK`, etc.) or TOML configuration.