### PR TITLE
awarpsharp: *actually* fix thresh scaling

### DIFF
--- a/vsrgtools/sharp.py
+++ b/vsrgtools/sharp.py
@@ -25,6 +25,7 @@ from vstools import (
     normalize_param_planes,
     normalize_planes,
     scale_delta,
+    scale_mask,
     scale_value,
     vs,
 )
@@ -116,7 +117,7 @@ def awarpsharp(
     """
     from vsmasktools import Sobel, normalize_mask
 
-    thresh = scale_delta(thresh, 8, clip)
+    thresh = scale_mask(thresh, 8, clip)
     mask_first_plane = fallback(mask_first_plane, clip.format.color_family is vs.YUV)
     mask_planes = 0 if mask_first_plane else planes
 


### PR DESCRIPTION
Fixes a regression introduced by 50bde6a2ece071d1a7c3f18203db1e2a1277ba80 where `scale_delta` replaced `scale_mask` when scaling `thresh` (the clamp applied to the mask to limit the strength of the warping). VapourSynth masks are always full-range, but `scale_delta` inherits the range of the clip being processed, which is typically limited-range. This results in incorrect limited-range scaling being applied to a full-range mask. Even if using `scale_delta` was intended to match legacy plugin behavior, the original scaling was broken and should not be replicated.