### PR TITLE
QTempGaussMC: Rewrite

### DIFF
--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1,18 +1,18 @@
-# ruff: noqa: B006, B008, RUF003
-from collections.abc import Generator, Mapping
-from contextlib import contextmanager, suppress
+from collections.abc import Mapping
+from contextlib import suppress
 from copy import deepcopy
 from enum import auto
 from math import comb
 from typing import Any, Literal, Protocol, Self, TypedDict
 
-from jetpytools import CustomIntEnum, CustomValueError, FuncExcept, fallback, normalize_seq
+from jetpytools import CustomIntEnum, CustomValueError, FuncExcept, cachedproperty, fallback, normalize_seq, to_arr
 
 from vsaa import NNEDI3
 from vsdeband import Grainer
 from vsdenoise import (
     DFTTest,
     MaskMode,
+    MotionVectors,
     MVDirection,
     MVTools,
     MVToolsPreset,
@@ -21,7 +21,6 @@ from vsdenoise import (
     refine_blksize,
 )
 from vsexprtools import norm_expr
-from vsjetpack import deprecated
 from vskernels import Bobber, BobberLike, Catrom
 from vsmasktools import Coordinates, Morpho
 from vsrgtools import BlurMatrix, gauss_blur, median_blur, remove_grain, repair, unsharpen
@@ -32,7 +31,6 @@ from vstools import (
     Planes,
     UnsupportedFieldBasedError,
     VSObject,
-    core,
     sc_detect,
     scale_delta,
     vs,
@@ -40,7 +38,11 @@ from vstools import (
 
 from .utils import reinterlace, reweave
 
-__all__ = ["QTempGaussMC"]
+__all__ = ["QTempGaussMC", "mask_shimmer"]
+
+
+_DFTTEST_DEFAULT = DFTTest(sigma=8)
+_NNEDI3_DEFAULT = NNEDI3(nsize=1)
 
 
 class _DenoiseFuncTr(Protocol):
@@ -50,43 +52,22 @@ class _DenoiseFuncTr(Protocol):
 class QTGMCArgs:
     """Namespace containing helper TypedDict definitions for various argument groups."""
 
+    class MaskShimmer(TypedDict, total=False):
+        """
+        Arguments accepted by [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer] through
+        [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter],
+        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
+        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
+        """
+
+        erosion_distance: int
+        over_dilation: int
+
     class PrefilterToFullRange(TypedDict, total=False):
         """Arguments accepted by [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range]."""
 
         slope: float
         smooth: float
-
-    class MaskShimmer(TypedDict, total=False):
-        """
-        Arguments accepted by the internal `_mask_shimmer` method through
-        [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter],
-        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
-        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
-
-        Removes areas of difference between a temporally blurred clip and a reference clip that are not due to
-        bob shimmer by only allowing thin horizontal areas of difference.
-
-        High-level overview:
-            - Vertical morphological analysis: Extracts the difference between source and filtered clips, running
-                vertical opening and closing operations to collapse thin bob shimmer while leaving large motion
-                artifacts intact.
-            - Safety margin adjustment: Applies extra dilation passes to fine-tune detection boundaries on soft sources,
-                ensuring proper mask coverage on blurry edges.
-        """
-
-        erosion_distance: int
-        """
-        Vertical radius for shimmer detection.
-
-        Larger values capture more spread-out shimmer artifacts on soft sources.
-        """
-
-        over_dilation: int
-        """
-        Extra dilation passes for safety margins.
-
-        Larger values shrink the mask boundary to prevent artifacts on blurry edges. Defaults to 0.
-        """
 
     class Compensate(TypedDict, total=False):
         """Arguments accepted by [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate]."""
@@ -109,7 +90,6 @@ class QTGMCArgs:
     class Mask(TypedDict, total=False):
         """Arguments accepted by [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]."""
 
-        delta: int
         ml: float | None
         gamma: float | None
         time: float | None
@@ -121,85 +101,7 @@ class QTGMCArgs:
         prec: int | None
 
 
-class QTempGaussMC(VSObject):
-    """
-    Quick Temporal Gaussian Motion Compensated (QTGMC)
-
-    A very high-quality deinterlacer with a range of features for both quality and convenience. These include extensive
-    noise processing capabilities, support for repair of progressive material, precision source matching, shutter speed
-    simulation, and more.
-
-    Originally based on TempGaussMC by Didée.
-
-    Basic usage: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
-
-    Alternate documentation reference: [AviSynth documentation](http://avisynth.nl/index.php/QTGMC)
-    """
-
-    mv: MVTools
-    """[MVTools][vsdenoise.mvtools.mvtools.MVTools] instance used during processing."""
-
-    clip: vs.VideoNode
-    """Clip to process."""
-
-    draft: vs.VideoNode
-    """
-    Draft processed clip, used as a base for [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter] and
-    [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
-    """
-
-    input: vs.VideoNode
-    """
-    Prepared input clip for high-quality interpolation. Used as a base for the internal `_interpolate` method.
-    """
-
-    bobbed: vs.VideoNode
-    """
-    High-quality bobbed clip, acting as a spatial interpolation base for
-    [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
-    [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
-    """
-
-    noise: vs.VideoNode
-    """Noise extracted by [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
-
-    prefilter_output: vs.VideoNode
-    """Output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter]."""
-
-    denoise_output: vs.VideoNode
-    """Output of [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
-
-    basic_output: vs.VideoNode
-    """Output of [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]."""
-
-    final_output: vs.VideoNode
-    """Output of [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final]."""
-
-    motion_blur_output: vs.VideoNode
-    """Output of [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur]."""
-
-    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
-    class SearchPostProcess(CustomIntEnum):
-        GAUSSBLUR = 0
-        GAUSSBLUR_EDGESOFTEN = 1
-
-    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
-    class NoiseProcessMode(CustomIntEnum):
-        IDENTIFY = 0
-        DENOISE = 1
-
-    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
-    class SharpenMode(CustomIntEnum):
-        UNSHARP = 0
-        UNSHARP_MINMAX = 1
-
-    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
-    class SourceMatchMode(CustomIntEnum):
-        NONE = 0
-        BASIC = 1
-        REFINED = 2
-        TWICE_REFINED = 3
-
+class _QTGMCBuilder:
     class NoiseDeintMode(CustomIntEnum):
         WEAVE = auto()
         """
@@ -257,6 +159,22 @@ class QTempGaussMC(VSObject):
         Temporal limiting is more accurate, but allows less sharpening. Applying sharpness limiting later in the
         algorithm leaves the result sharper, but can produce additional artifacts.
         """
+
+        @cachedproperty
+        def is_spatial(self) -> bool:
+            return self in (self.SPATIAL_PRESMOOTH, self.SPATIAL_POSTSMOOTH)
+
+        @cachedproperty
+        def is_temporal(self) -> bool:
+            return self in (self.TEMPORAL_PRESMOOTH, self.TEMPORAL_POSTSMOOTH)
+
+        @cachedproperty
+        def is_presmooth(self) -> bool:
+            return self in (self.SPATIAL_PRESMOOTH, self.TEMPORAL_PRESMOOTH)
+
+        @cachedproperty
+        def is_postsmooth(self) -> bool:
+            return self in (self.SPATIAL_POSTSMOOTH, self.TEMPORAL_POSTSMOOTH)
 
     class BackBlendMode(CustomIntEnum):
         NONE = auto()
@@ -319,12 +237,11 @@ class QTempGaussMC(VSObject):
     def __init__(self, **kwargs: Any) -> None:
         """
         Args:
-            **kwargs: Additional arguments to be passed to the parameter category methods. Use the method's name as a
-                prefix to pass an argument to the respective method.
+            **kwargs: Additional arguments to be passed to the parameter category methods. Separate the method name
+                from its argument with two underscores, for example `sharpen_limit__mode`.
         """
 
-        # Set default parameters for all the categories in this exact order
-        self._settings_methods = (
+        settings_methods = (
             self.prefilter,
             self.analyze,
             self.denoise,
@@ -338,8 +255,8 @@ class QTempGaussMC(VSObject):
             self.motion_blur,
         )
 
-        for method in self._settings_methods:
-            prefix = f"{method.__name__}_"
+        for method in settings_methods:
+            prefix = f"{method.__name__}__"
 
             method(**{k.removeprefix(prefix): kwargs.pop(k) for k in tuple(kwargs) if k.startswith(prefix)})
 
@@ -351,12 +268,11 @@ class QTempGaussMC(VSObject):
         *,
         tr: int = 2,
         sc_threshold: float = 0.1,
-        postprocess: SearchPostProcess | None = None,
         strength: tuple[float, float] = (1.9, 0.9),
         limit: tuple[float, float, float] = (3, 7, 2),
         bias: float = 0.51,
         range_expansion_args: QTGMCArgs.PrefilterToFullRange | None = None,
-        mask_shimmer_args: QTGMCArgs.MaskShimmer | None = {"erosion_distance": 4},
+        mask_shimmer_args: QTGMCArgs.MaskShimmer | None = None,
     ) -> Self:
         """
         Configures parameters for the prefilter stage.
@@ -364,11 +280,11 @@ class QTempGaussMC(VSObject):
         Prepares a suitable search clip to be provided for motion analysis purposes.
 
         High-level overview:
-            - [[QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]] Draft bobbed clip generation:
+            - ([QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]) Draft bobbed clip generation:
                 Begins with simple spatial interpolation to produce
                 [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft], which inherently contains severe temporal
                 instability known as bob shimmer.
-            - [[QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]] Vertical spatial pre-filtering: Applies a
+            - ([QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]) Vertical spatial pre-filtering: Applies a
                 vertical binomial blur to filter out residual vertical artifacts.
             - Temporal binomial blurring: Applies a temporal binomial blur to smooth
                 [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft], removing the shimmer, which prevents
@@ -397,7 +313,7 @@ class QTempGaussMC(VSObject):
                     Gaussian-blurred clip.
 
                 Defaults to (1.9, 0.9).
-            limit: Tuple containing the 3-step limiting (8-bit) thresholds for the Gaussian blur post-processing:
+            limit: Tuple containing the 3-step limiting thresholds (8-bit) for the Gaussian blur post-processing:
 
                    - First value: Maximum allowed delta between the temporally blurred clip and
                    [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft]. Smaller values clamp
@@ -413,29 +329,26 @@ class QTempGaussMC(VSObject):
                 values give more weight to the Gaussian-blurred clip. Defaults to 0.51.
             range_expansion_args: Additional arguments passed to
                 [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range]. Defaults to None.
-            mask_shimmer_args: Additional arguments passed to the internal `_mask_shimmer` call. Defaults to
-                {"erosion_distance": 4}.
+            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
+                to None.
         """
 
         self.prefilter_tr = tr
         self.prefilter_sc_threshold = sc_threshold
-        self.prefilter_postprocess = postprocess
         self.prefilter_strength = strength
         self.prefilter_limit = limit
         self.prefilter_bias = bias
         self.prefilter_range_expansion_args = fallback(range_expansion_args, QTGMCArgs.PrefilterToFullRange())
         self.prefilter_mask_shimmer_args = fallback(mask_shimmer_args, QTGMCArgs.MaskShimmer())
 
-        if postprocess is not None and not postprocess.value:  # TODO: remove
-            self.prefilter_limit = (0, 0, 0)
-
         return self
 
     def analyze(
         self,
         *,
-        force_tr: int = 0,
+        vectors: MotionVectors | None = None,
         preset: Mapping[str, Any] = MVToolsPreset.HQ_SAD,
+        force_tr: int = 0,
         blksize: int | tuple[int, int] = 16,
         overlap: int | tuple[int, int] = 2,
         refine: int = 1,
@@ -454,14 +367,16 @@ class QTempGaussMC(VSObject):
                 [MVTools.recalculate][vsdenoise.mvtools.mvtools.MVTools.recalculate] to improve motion vector precision.
 
         Args:
-            force_tr: Always analyze motion to at least this value, even if otherwise unnecessary. Useful if you want to
-                reuse the generated motion vectors for other tasks. Defaults to 0.
+            vectors: Motion vectors to use instead of internally generating them. Defaults to None.
             preset: [MVTools][vsdenoise.mvtools.mvtools.MVTools] preset defining base values for
                 [MVTools][vsdenoise.mvtools.mvtools.MVTools]. Defaults to MVToolsPreset.HQ_SAD.
-            blksize: Motion analysis block size. Larger blocks are faster and less sensitive to noise, but less
-                accurate. Defaults to 16.
-            overlap: The block size divisor for block size overlap. Larger overlap reduces blocking artifacts of
-                [MVTools][vsdenoise.mvtools.mvtools.MVTools] processes. Defaults to 2.
+            force_tr: Always analyze motion to at least this value, even if otherwise unnecessary. Useful if you want to
+                reuse the generated motion vectors for other tasks. Defaults to 0.
+            blksize: Motion analysis block size. Larger values are faster and less sensitive to noise, but less
+                accurate. Passing a tuple of values results in asymmetric block sizes. Defaults to 16.
+            overlap: The block size divisor for block size overlap. Smaller values reduce blocking artifacts of
+                [MVTools][vsdenoise.mvtools.mvtools.MVTools] processes. Passing a tuple of values results in asymmetric
+                overlap. Defaults to 2.
             refine: Number of iterations to recalculate motion vectors with halved block size. Improves motion vector
                 precision without reducing denoising effectiveness. Defaults to 1.
             thsad_recalc: Only poor-quality new vectors with a SAD above this value will be re-estimated by motion
@@ -475,8 +390,9 @@ class QTempGaussMC(VSObject):
                 Defaults to (180, 38.5).
         """
 
-        self.analyze_force_tr = force_tr
+        self.analyze_vectors = vectors
         self.analyze_preset = preset
+        self.analyze_force_tr = force_tr
         self.analyze_blksize = blksize
         self.analyze_overlap = overlap
         self.analyze_refine = refine
@@ -485,12 +401,19 @@ class QTempGaussMC(VSObject):
 
         return self
 
+    @property
+    def analyze_thsad_recalc(self) -> int:
+        return fallback(self._analyze_thsad_recalc, round(to_arr(self.basic_thsad)[0] / 2))
+
+    @analyze_thsad_recalc.setter
+    def analyze_thsad_recalc(self, value: int | None) -> None:
+        self._analyze_thsad_recalc = value
+
     def denoise(
         self,
         *,
         tr: int = 1,
-        func: DFTTest | _DenoiseFuncTr = DFTTest(sigma=8),
-        mode: NoiseProcessMode | None = None,
+        func: DFTTest | _DenoiseFuncTr = _DFTTEST_DEFAULT,
         deint: NoiseDeintMode = NoiseDeintMode.GENERATE,
         full_denoise: bool = False,
         mc_denoise: bool = True,
@@ -514,7 +437,7 @@ class QTempGaussMC(VSObject):
 
             - Motion-compensated denoising: Motion compensation can optionally be used during the denoising to improve
                 the accuracy of the noise estimation.
-            - [[QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]] Interlaced noise processing: Because
+            - ([QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]) Interlaced noise processing: Because
                 the extracted noise is inherently interlaced and standard processing would eliminate it, three
                 alternative methods ([QTempGaussMC.NoiseDeintMode][vsdeinterlace.QTempGaussMC.NoiseDeintMode]) are
                 available to process it separately.
@@ -550,9 +473,6 @@ class QTempGaussMC(VSObject):
         self.denoise_func_comp_args = fallback(func_comp_args, QTGMCArgs.Compensate())
         self.denoise_stabilize_comp_args = fallback(stabilize_comp_args, QTGMCArgs.Compensate())
 
-        if mode is not None:  # TODO: remove
-            self.denoise_full_denoise = bool(mode)
-
         return self
 
     def basic(
@@ -560,11 +480,12 @@ class QTempGaussMC(VSObject):
         *,
         tr: int = 2,
         thsad: int | tuple[int, int] = 640,
-        bobber: BobberLike = NNEDI3(nsize=1),
+        thsad2: int | tuple[int, int] | None = None,
+        bobber: BobberLike = _NNEDI3_DEFAULT,
         noise_restore: float = 0,
         degrain_args: QTGMCArgs.Degrain | None = None,
-        mask_args: QTGMCArgs.Mask | None = {"ml": 10},
-        mask_shimmer_args: QTGMCArgs.MaskShimmer | None = {"erosion_distance": 0},
+        mask_args: QTGMCArgs.Mask | None = None,
+        mask_shimmer_args: QTGMCArgs.MaskShimmer | None = None,
     ) -> Self:
         """
         Configures parameters for the basic stage.
@@ -575,7 +496,7 @@ class QTempGaussMC(VSObject):
             - High-quality bobbed clip generation: Begins with high-quality spatial interpolation to produce
                 [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], which inherently contains severe temporal
                 instability known as bob shimmer.
-            - [[QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]] Motion SAD masking: Generates a motion-vector
+            - ([QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]) Motion SAD masking: Generates a motion-vector
                 SAD mask to blend [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] output over
                 [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], protecting static/low-motion detail.
             - Motion-compensated temporal binomial smoothing: Applies a motion-compensated temporal binomial blur to
@@ -591,31 +512,36 @@ class QTempGaussMC(VSObject):
                 - [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit]
 
             - Noise restoration: Optionally restores noise previously extracted by
-                [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of the pipeline.
+                [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of this stage.
 
         Args:
             tr: Temporal radius of the motion-compensated binomial blur. Larger values reduce more shimmer but can
                 introduce blurring and ghosting. Defaults to 2.
             thsad: SAD threshold of the motion-compensated binomial blur. Larger values reduce more shimmer but can
-                introduce blurring and ghosting. Defaults to 640.
+                introduce blurring and ghosting. Passing a tuple of values results in per-plane thresholds. Defaults to
+                640.
+            thsad2: Second SAD threshold of the motion-compensated linear blur. Larger values clean more artifacts but
+                can introduce blurring and ghosting. Passing a tuple of values results in per-plane thresholds. Defaults
+                to None.
             bobber: Bobber to use for spatial interpolation. Defaults to NNEDI3(nsize=1).
             noise_restore: Amount of noise to restore after this stage. Used to retain stable noise. Defaults to 0.
             degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
             mask_args: Additional arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]. Only used
                 for [QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]. Defaults to {"ml": 10}.
-            mask_shimmer_args: Additional arguments passed to the internal `_mask_shimmer` call. Defaults to
-                {"erosion_distance": 0}.
+            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
+                to {"erosion_distance": 0}.
         """
 
         self.basic_tr = tr
         self.basic_thsad = thsad
+        self.basic_thsad2 = thsad2
         self.basic_bobber = (
             deepcopy(bobber) if isinstance(bobber, Bobber) else Bobber.ensure_obj(bobber, self.__class__)
         )
         self.basic_noise_restore = noise_restore
         self.basic_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
-        self.basic_mask_args = fallback(mask_args, QTGMCArgs.Mask())
-        self.basic_mask_shimmer_args = fallback(mask_shimmer_args, QTGMCArgs.MaskShimmer())
+        self.basic_mask_args = QTGMCArgs.Mask(ml=10) | (mask_args or {})
+        self.basic_mask_shimmer_args = QTGMCArgs.MaskShimmer(erosion_distance=0) | (mask_shimmer_args or {})
 
         return self
 
@@ -625,7 +551,6 @@ class QTempGaussMC(VSObject):
         tr: int = 1,
         bobber: BobberLike | None = None,
         iterations: Literal[0, 1, 2, 3] = 0,
-        mode: SourceMatchMode | None = None,
         similarity: float = 0.5,
         enhance: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
@@ -659,7 +584,8 @@ class QTempGaussMC(VSObject):
                 [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `bobber`.
             iterations: Number of source match iterations to perform. Higher values are slower and more accurate. Using
                 2 or 3 iterations restores almost exact source detail but is sensitive to noise and introduces
-                occasional aliasing (to a lesser extent for 3). Defaults to 0.
+                occasional aliasing (to a lesser extent for 3). Requires
+                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `tr` > 0 Defaults to 0.
             similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
                 Defaults to 0.5.
             enhance: Enhances detail found by `iterations` > 1. Higher values exaggerate detail more. Defaults to 0.5.
@@ -672,9 +598,6 @@ class QTempGaussMC(VSObject):
         self.source_match_similarity = similarity
         self.source_match_enhance = enhance
         self.source_match_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
-
-        if mode is not None:  # TODO: remove
-            self.source_match_iterations = mode.value  # type: ignore
 
         return self
 
@@ -719,7 +642,6 @@ class QTempGaussMC(VSObject):
     def sharpen(
         self,
         *,
-        mode: SharpenMode | None = None,
         strength: float | None = None,
         offset: float | tuple[float, float] | Literal[False] = 1,
         thin: float = 0,
@@ -739,9 +661,9 @@ class QTempGaussMC(VSObject):
         Args:
             strength: Sharpening strength. Higher values result in more sharpening. Defaults to 1 when
                 [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0, and 0 otherwise.
-            offset: Offsets the blur source to the vertical min/max average ±this value. Smaller values result in more
-                vertical sharpening. Passing a tuple of values results in asymmetric offsetting. `False` disables
-                range limiting. Defaults to 1.
+            offset: Offsets the blur source to the vertical min/max average ± this value (8-bit). Smaller values result
+                in more vertical sharpening. Passing a tuple of values results in asymmetric offsetting. `False`
+                disables range limiting. Defaults to 1.
             thin: How much to thin down horizontal edges. Higher values result in more thinning. Defaults to 0.
         """
 
@@ -749,14 +671,11 @@ class QTempGaussMC(VSObject):
         self.sharpen_offset = offset is not False and normalize_seq(offset, 2)
         self.sharpen_thin = thin
 
-        if mode is not None and not mode.value:  # TODO: remove
-            self.sharpen_offset = False
-
         return self
 
     @property
     def sharpen_strength(self) -> float:
-        return fallback(self._sharpen_strength, 0 if self.source_match_iterations else 1)
+        return fallback(self._sharpen_strength, 0 if self._source_match_enabled else 1)
 
     @sharpen_strength.setter
     def sharpen_strength(self, value: float | None) -> None:
@@ -813,8 +732,8 @@ class QTempGaussMC(VSObject):
                 [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0 and
                 SharpenLimitMode.NONE otherwise.
             radius: Radius of the sharpness limiting. Larger values allow more sharpening. Defaults to 1.
-            clamp: How much undershoot/overshoot to allow. Larger values result in less limiting. Passing a tuple of
-                values allows for asymmetric limiting. Defaults to 0.
+            clamp: How much undershoot/overshoot to allow (8-bit). Larger values result in less limiting. Passing a
+                tuple of values allows for asymmetric limiting. Defaults to 0.
             comp_args: Additional arguments passed to [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate]
                 for temporal limiting. Defaults to None.
         """
@@ -830,7 +749,7 @@ class QTempGaussMC(VSObject):
     def sharpen_limit_mode(self) -> SharpenLimitMode:
         return fallback(
             self._sharpen_limit_mode,
-            self.SharpenLimitMode.NONE if self.source_match_iterations else self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
+            self.SharpenLimitMode.NONE if self._source_match_enabled else self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
         )
 
     @sharpen_limit_mode.setter
@@ -842,9 +761,10 @@ class QTempGaussMC(VSObject):
         *,
         tr: int = 1,
         thsad: int | tuple[int, int] = 256,
+        thsad2: int | tuple[int, int] | None = None,
         noise_restore: float = 0,
         degrain_args: QTGMCArgs.Degrain | None = None,
-        mask_shimmer_args: QTGMCArgs.MaskShimmer | None = {"erosion_distance": 4},
+        mask_shimmer_args: QTGMCArgs.MaskShimmer | None = None,
     ) -> Self:
         """
         Configures parameters for the final stage.
@@ -861,22 +781,27 @@ class QTempGaussMC(VSObject):
                 - [QTempGaussMC.lossless][vsdeinterlace.QTempGaussMC.lossless]
 
             - Noise restoration: Optionally restores noise previously extracted by
-                [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of the pipeline.
+                [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of this stage.
 
         Args:
             tr: Temporal radius of the motion-compensated linear blur. Larger values clean more artifacts but can
                 introduce blurring and ghosting. Defaults to 1.
             thsad: SAD threshold of the motion-compensated linear blur. Larger values clean more artifacts but can
-                introduce blurring and ghosting. Defaults to 256.
+                introduce blurring and ghosting. Passing a tuple of values results in per-plane thresholds. Defaults to
+                256.
+            thsad2: Second SAD threshold of the motion-compensated linear blur. Larger values clean more artifacts but
+                can introduce blurring and ghosting. Passing a tuple of values results in per-plane thresholds. Defaults
+                to None.
             noise_restore: Amount of noise to restore after this stage. Used to retain any noise. Defaults to 0.
             degrain_args: Additional arguments passed to [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain].
                 Defaults to None.
-            mask_shimmer_args: Additional arguments passed to the internal `_mask_shimmer` call. Defaults to
-                {"erosion_distance": 4}.
+            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
+                to None.
         """
 
         self.final_tr = tr
         self.final_thsad = thsad
+        self.final_thsad2 = thsad2
         self.final_noise_restore = noise_restore
         self.final_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
         self.final_mask_shimmer_args = fallback(mask_shimmer_args, QTGMCArgs.MaskShimmer())
@@ -889,7 +814,7 @@ class QTempGaussMC(VSObject):
         shutter_angle: tuple[float, float] = (180, 180),
         fps_divisor: int = 1,
         blur_args: QTGMCArgs.Blur | None = None,
-        mask_args: QTGMCArgs.Mask | None = {"ml": 4},
+        mask_args: QTGMCArgs.Mask | None = None,
     ) -> Self:
         """
         Configures parameters for the motion blur stage.
@@ -919,50 +844,157 @@ class QTempGaussMC(VSObject):
         self.motion_blur_shutter_angle = shutter_angle
         self.motion_blur_fps_divisor = fps_divisor
         self.motion_blur_blur_args = fallback(blur_args, QTGMCArgs.Blur())
-        self.motion_blur_mask_args = fallback(mask_args, QTGMCArgs.Mask())
+        self.motion_blur_mask_args = QTGMCArgs.Mask(ml=4) | (mask_args or {})
 
         return self
 
-    def _mask_shimmer(
-        self,
-        flt: vs.VideoNode,
-        src: vs.VideoNode,
-        erosion_distance: int,
-        over_dilation: int = 0,
-    ) -> vs.VideoNode:
-        if not erosion_distance:
-            return flt
+    @property
+    def _denoise_enabled(self) -> bool:
+        return self.denoise_full_denoise or self._noise_restore_enabled
 
-        ed_iter1 = 1 + erosion_distance // 3
-        ed_iter2 = 1 + (erosion_distance + 1) // 3
-        ed_res = erosion_distance % 3
-        od_iter1, od_iter2 = divmod(over_dilation, 3)
+    @property
+    def _noise_restore_enabled(self) -> bool:
+        return bool(self.basic_noise_restore or self.final_noise_restore)
 
-        diff = src.std.MakeDiff(flt)
+    @property
+    def _stabilization_enabled(self) -> bool:
+        return self.denoise_stabilize is not False and self._noise_restore_enabled
 
-        processed = list[vs.VideoNode]()
-        for grow_op, shrink_op, inflate_op, deflate_op in [
-            (Morpho.maximum, Morpho.minimum, Morpho.inflate, Morpho.deflate),
-            (Morpho.minimum, Morpho.maximum, Morpho.deflate, Morpho.inflate),
-        ]:
-            clip = grow_op(diff, iterations=ed_iter1, coords=Coordinates.VERTICAL, func=self._mask_shimmer)
+    @property
+    def _source_match_enabled(self) -> bool:
+        return bool(self.source_match_iterations and self.basic_tr)
 
-            if ed_res:
-                clip = inflate_op(clip, func=self._mask_shimmer)
-                if ed_res == 2:
-                    clip = median_blur(clip, func=self._mask_shimmer)
-
-            clip = shrink_op(clip, iterations=ed_iter2, coords=Coordinates.VERTICAL, func=self._mask_shimmer)
-
-            if over_dilation:
-                clip = shrink_op(clip, iterations=od_iter1, func=self._mask_shimmer)
-                clip = deflate_op(clip, iterations=od_iter2, func=self._mask_shimmer)
-
-            processed.append(clip)
-
-        return norm_expr(
-            [flt, diff, *processed], "x y z neutral min a neutral max clamp neutral - +", func=self._mask_shimmer
+    @property
+    def _sharpening_enabled(self) -> bool:
+        return bool(
+            (self.sharpen_strength or self.sharpen_thin)
+            and (self.backblend_mode == self.BackBlendMode.NONE or self.backblend_sigma)
         )
+
+    @property
+    def _sharpness_limiting_enabled(self) -> bool:
+        return bool(
+            self._sharpening_enabled
+            and self.sharpen_limit_mode != self.SharpenLimitMode.NONE
+            and self.sharpen_limit_radius
+        )
+
+
+class QTempGaussMC(_QTGMCBuilder, VSObject):
+    """
+    Quick Temporal Gaussian Motion Compensated (QTGMC)
+
+    A very high-quality deinterlacer with a range of features for both quality and convenience. These include extensive
+    noise processing capabilities, support for repair of progressive material, precision source matching, shutter speed
+    simulation, and more.
+
+    Originally based on TempGaussMC by Didée.
+
+    Basic usage: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+
+    Alternate documentation reference: [AviSynth documentation](http://avisynth.nl/index.php/QTGMC)
+    """
+
+    func: FuncExcept
+    """Processing method in use."""
+
+    mv: MVTools
+    """
+    [MVTools][vsdenoise.mvtools.mvtools.MVTools] instance used during processing.
+
+    Only available after processing a clip that requires motion analysis.
+    """
+
+    tff: FieldBased
+    """Field order used during processing."""
+
+    clip: vs.VideoNode
+    """Clip to process."""
+
+    draft: vs.VideoNode
+    """
+    Draft processed clip, used as a base for [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter] and
+    [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
+
+    Only available after processing a clip that requires motion-vector processing or denoising.
+    """
+
+    bob_input: vs.VideoNode
+    """
+    Prepared input clip for high-quality interpolation. Used as a base for the internal `_interpolate` method and as a
+    reference for [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
+    """
+
+    bobbed: vs.VideoNode
+    """
+    High-quality bobbed clip, acting as a spatial interpolation base for
+    [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
+    [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
+    """
+
+    noise: vs.VideoNode
+    """
+    Noise extracted by [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
+
+    Only available after processing a clip that requires noise restoration.
+    """
+
+    prefilter_output: vs.VideoNode
+    """
+    Output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter].
+
+    Only available after processing a clip that requires internally generated motion vectors.
+    """
+
+    denoise_output: vs.VideoNode
+    """Output of [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
+
+    basic_output: vs.VideoNode
+    """Output of [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]."""
+
+    final_output: vs.VideoNode
+    """Output of [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final]."""
+
+    motion_blur_output: vs.VideoNode
+    """Output of [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur]."""
+
+    @property
+    def _is_deinterlace(self) -> bool:
+        return self.tff.is_inter and not self._is_repair
+
+    @property
+    def _is_repair(self) -> bool:
+        return self.func == self.repair
+
+    @property
+    def _required_analyze_tr(self) -> int:
+        return max(
+            self.analyze_force_tr,
+            self.denoise_tr if self.denoise_mc_denoise and self._denoise_enabled else 0,
+            self._stabilization_enabled,
+            self.basic_tr,
+            self._repair_mask_enabled,
+            self.source_match_tr if self.source_match_iterations > 1 and self._source_match_enabled else 0,
+            self.sharpen_limit_radius
+            if self.sharpen_limit_mode.is_temporal and self._sharpness_limiting_enabled
+            else 0,
+            self.final_tr,
+            bool(self._motion_blur_level),
+        )
+
+    @property
+    def _repair_mask_enabled(self) -> bool:
+        return bool(self._is_repair and self.basic_mask_args.get("ml", 0))
+
+    @property
+    def _motion_blur_level(self) -> float:
+        angle_in, angle_out = self.motion_blur_shutter_angle
+
+        return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
+
+    @property
+    def _motion_blur_fps_divisor(self) -> int:
+        return 1 if self.func == self.bob else self.motion_blur_fps_divisor
 
     def _interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
         if self.tff.is_inter:
@@ -978,15 +1010,24 @@ class QTempGaussMC(VSObject):
             clip,
             tr=tr,
             thsad=self.basic_thsad,
+            thsad2=self.basic_thsad2,
             thscd=self.analyze_thscd,
             weights=BlurMatrix.BINOMIAL(radius=tr),
             **degrain_args,
         )
 
     def _apply_prefilter(self) -> None:
-        self.draft = Catrom().bob(self.clip, tff=self.tff) if self.tff.is_inter and not self.is_repair else self.clip
+        analyze_tr = self._required_analyze_tr
 
-        if self.is_repair:
+        if not (analyze_tr or self._denoise_enabled):
+            return
+
+        self.draft = Catrom().bob(self.clip, tff=self.tff) if self._is_deinterlace else self.clip
+
+        if not analyze_tr or self.analyze_vectors:
+            return
+
+        if self._is_repair:
             search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self._apply_prefilter)
         else:
             search = self.draft
@@ -995,76 +1036,60 @@ class QTempGaussMC(VSObject):
             smoothed = BlurMatrix.BINOMIAL(self.prefilter_tr, mode=ConvMode.TEMPORAL)(
                 sc_detect(search, self.prefilter_sc_threshold), scenechange=True, func=self._apply_prefilter
             )
-            smoothed = self._mask_shimmer(smoothed, search, **self.prefilter_mask_shimmer_args)
+            smoothed = mask_shimmer(smoothed, search, **self.prefilter_mask_shimmer_args, func=self._apply_prefilter)
         else:
             smoothed = search
 
         gauss_sigma, blend_weight = self.prefilter_strength
         lim1, lim2, lim3 = [scale_delta(thr, 8, self.clip) for thr in self.prefilter_limit]
+        apply_blur = bool(gauss_sigma and blend_weight)
 
-        # TODO: Figure out early exits
-        blurred = gauss_blur(smoothed, gauss_sigma) if gauss_sigma and blend_weight else smoothed
-        blurred = norm_expr(
-            [blurred, smoothed, search],
-            "y x y - {weight} * + BLUR! z y {lim1} - y {lim1} + clamp TWEAK! "
-            "BLUR@ {lim2} + TWEAK@ < BLUR@ {lim3} + BLUR@ {lim2} - TWEAK@ > BLUR@ {lim3} - "
-            "TWEAK@ BLUR@ TWEAK@ - {bias} * + ? ?",
-            weight=blend_weight,
-            lim1=lim1,
-            lim2=lim2,
-            lim3=lim3,
-            bias=self.prefilter_bias,
-            func=self._apply_prefilter,
-        )
+        blurred = gauss_blur(smoothed, gauss_sigma) if apply_blur else smoothed
+
+        if apply_blur or (self.prefilter_tr and lim1 and (lim2 or lim3)):
+            blurred = norm_expr(
+                [blurred, smoothed, search],
+                "y x y - {weight} * + BLUR! z y {lim1} - y {lim1} + clamp TWEAK! "
+                "BLUR@ {lim2} + TWEAK@ < BLUR@ {lim3} + BLUR@ {lim2} - TWEAK@ > BLUR@ {lim3} - "
+                "TWEAK@ BLUR@ TWEAK@ - {bias} * + ? ?",
+                weight=blend_weight,
+                lim1=lim1,
+                lim2=lim2,
+                lim3=lim3,
+                bias=self.prefilter_bias,
+                func=self._apply_prefilter,
+            )
 
         self.prefilter_output = prefilter_to_full_range(
             blurred, func=self._apply_prefilter, **self.prefilter_range_expansion_args
         )
 
     def _apply_analyze(self) -> None:
-        angle_in, angle_out = self.motion_blur_shutter_angle
+        tr = self._required_analyze_tr
 
-        tr = max(
-            # Unconditional radii
-            self.analyze_force_tr,
-            self.basic_tr,
-            self.source_match_tr,
-            self.final_tr,
-            # Conditional radii
-            self.denoise_tr if self.denoise_mc_denoise else 0,
-            self.sharpen_limit_radius
-            if self.sharpen_limit_mode
-            in {self.SharpenLimitMode.TEMPORAL_PRESMOOTH, self.SharpenLimitMode.TEMPORAL_POSTSMOOTH}
-            and (self.sharpen_strength or self.sharpen_thin)
-            else 0,
-            # Feature flags
-            int(self.denoise_stabilize is not False and (self.basic_noise_restore or self.final_noise_restore)),
-            int(bool(self.is_repair and self.basic_mask_args.get("ml"))),
-            int(angle_out * self.motion_blur_fps_divisor != angle_in),
-        )
+        if not tr:
+            return
 
         blksize = self.analyze_blksize
-        thsad_recalc = fallback(
-            self.analyze_thsad_recalc,
-            round((self.basic_thsad[0] if isinstance(self.basic_thsad, tuple) else self.basic_thsad) / 2),
-        )
+        if not self.analyze_vectors:
+            preset = {**self.analyze_preset, "search_clip": self.prefilter_output}
 
-        self.mv = MVTools(self.draft, **{**self.analyze_preset, "search_clip": self.prefilter_output})
-        self.mv.analyze(tr=tr, blksize=blksize, overlap_div=self.analyze_overlap)
+        self.mv = MVTools(self.draft, vectors=self.analyze_vectors, **preset)
 
-        for _ in range(self.analyze_refine):
-            blksize = refine_blksize(blksize)
-            self.mv.recalculate(thsad=thsad_recalc, blksize=blksize, overlap_div=self.analyze_overlap)
+        if not self.analyze_vectors:
+            self.mv.analyze(tr=tr, blksize=blksize, overlap_div=self.analyze_overlap)
+
+            for _ in range(self.analyze_refine):
+                blksize = refine_blksize(blksize)
+                self.mv.recalculate(thsad=self.analyze_thsad_recalc, blksize=blksize, overlap_div=self.analyze_overlap)
 
     def _apply_denoise(self) -> None:
         self.denoise_output = self.clip
 
-        no_restore = self.basic_noise_restore == self.final_noise_restore == 0
-
-        if not self.denoise_full_denoise and no_restore:
+        if not self._denoise_enabled:
             return
 
-        if self.denoise_mc_denoise:
+        if self.denoise_mc_denoise and self.denoise_tr:
             denoised = self.mv.compensate(
                 tr=self.denoise_tr,
                 thscd=self.analyze_thscd,
@@ -1074,18 +1099,18 @@ class QTempGaussMC(VSObject):
         else:
             denoised = self.denoise_func(self.draft, tr=self.denoise_tr)
 
-        if self.tff.is_inter and not self.is_repair:
+        if self._is_deinterlace:
             denoised = reinterlace(denoised, self.tff, self._apply_denoise)
 
         if self.denoise_full_denoise:
             self.denoise_output = denoised
 
-        self.noise = self.clip.std.MakeDiff(denoised)
-
-        if no_restore:
+        if not self._noise_restore_enabled:
             return
 
-        if self.tff.is_inter and not self.is_repair:
+        self.noise = self.clip.std.MakeDiff(denoised)
+
+        if self._is_deinterlace:
             match self.denoise_deint:
                 case self.NoiseDeintMode.WEAVE:
                     new_noise = self.noise.std.SeparateFields(self.tff.is_tff).std.DoubleWeave(self.tff.is_tff)
@@ -1099,7 +1124,7 @@ class QTempGaussMC(VSObject):
 
                     gen_noise = Grainer.GAUSS(
                         noise_source,
-                        ((0.5 * 255) / 3) ** 2,  # 3σ rule
+                        ((0.5 * 255) / 3) ** 2,  # 3σ rule  # noqa: RUF003
                         protect_edges=False,
                         protect_neutral_chroma=False,
                         neutral_out=True,
@@ -1113,7 +1138,7 @@ class QTempGaussMC(VSObject):
 
             self.noise = FieldBased.PROGRESSIVE.apply(new_noise)
 
-        if self.denoise_stabilize is not False:
+        if self._stabilization_enabled:
             noise_comp, _ = self.mv.compensate(
                 self.noise,
                 direction=MVDirection.BACKWARD,
@@ -1125,21 +1150,20 @@ class QTempGaussMC(VSObject):
 
             self.noise = norm_expr(
                 [self.noise, *noise_comp],
-                "x neutral - abs y neutral - abs > x y ? {weight2} * x y + {weight1} * +",
-                weight1=self.denoise_stabilize / 2,
-                weight2=1 - self.denoise_stabilize,
+                "x neutral - abs y neutral - abs > x y ? dup x y + 2 / swap - {weight} * +",
+                weight=self.denoise_stabilize,
                 func=self._apply_denoise,
             )
 
     def _apply_basic(self) -> None:
-        if self.is_repair:
-            self.input = reinterlace(self.denoise_output, self.tff, self._interpolate)
+        if self._is_repair:
+            self.bob_input = reinterlace(self.denoise_output, self.tff, self._apply_basic)
         else:
-            self.input = self.denoise_output
+            self.bob_input = self.denoise_output
 
-        self.bobbed = self._interpolate(self.input, self.basic_bobber)
+        self.bobbed = self._interpolate(self.bob_input, self.basic_bobber)
 
-        if self.is_repair and self.basic_mask_args.get("ml", 0):
+        if self._repair_mask_enabled:
             mask = self.mv.mask(
                 direction=MVDirection.BACKWARD,
                 kind=MaskMode.SAD,
@@ -1151,29 +1175,29 @@ class QTempGaussMC(VSObject):
         smoothed = self._binomial_degrain(self.bobbed, self.basic_tr, **self.basic_degrain_args)
 
         if self.basic_tr:
-            smoothed = self._mask_shimmer(smoothed, self.bobbed, **self.basic_mask_shimmer_args)
+            smoothed = mask_shimmer(smoothed, self.bobbed, **self.basic_mask_shimmer_args, func=self._apply_basic)
 
-            if self.source_match_iterations:
-                smoothed = self._apply_source_match(smoothed)
+        if self._source_match_enabled:
+            smoothed = self._apply_source_match(smoothed)
 
         if self.lossless_mode == self.LosslessMode.PRESHARPEN:
             smoothed = self._apply_lossless(smoothed)
 
-        resharp = self._apply_sharpen(smoothed)
+        if self._sharpening_enabled:
+            resharp = self._apply_sharpen(smoothed)
 
-        if self.sharpen_limit_mode in {
-            self.SharpenLimitMode.SPATIAL_PRESMOOTH,
-            self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
-        }:
-            if self.backblend_mode in {self.BackBlendMode.PRELIMIT, self.BackBlendMode.BOTH}:
+            if self._sharpness_limiting_enabled and self.sharpen_limit_mode.is_presmooth:
+                if self.backblend_mode in (self.BackBlendMode.PRELIMIT, self.BackBlendMode.BOTH):
+                    resharp = self._apply_back_blend(resharp, smoothed)
+
+                resharp = self._apply_sharpen_limit(resharp)
+
+                if self.backblend_mode in (self.BackBlendMode.POSTLIMIT, self.BackBlendMode.BOTH):
+                    resharp = self._apply_back_blend(resharp, smoothed)
+            elif self.backblend_mode != self.BackBlendMode.NONE:
                 resharp = self._apply_back_blend(resharp, smoothed)
-
-            resharp = self._apply_sharpen_limit(resharp)
-
-            if self.backblend_mode in {self.BackBlendMode.POSTLIMIT, self.BackBlendMode.BOTH}:
-                resharp = self._apply_back_blend(resharp, smoothed)
-        elif self.backblend_mode != self.BackBlendMode.NONE:
-            resharp = self._apply_back_blend(resharp, smoothed)
+        else:
+            resharp = smoothed
 
         self.basic_output = self._apply_noise_restore(resharp, self.basic_noise_restore)
 
@@ -1192,7 +1216,7 @@ class QTempGaussMC(VSObject):
         if self.tff.is_inter:
             clip = reinterlace(clip, self.tff, self._apply_source_match)
 
-        adjusted = _error_adjustment(self.input, clip, self.basic_tr)
+        adjusted = _error_adjustment(self.bob_input, clip, self.basic_tr)
         new_bobbed = self._interpolate(adjusted, self.basic_bobber)
         matched = self._binomial_degrain(new_bobbed, self.basic_tr, **self.basic_degrain_args)
 
@@ -1204,7 +1228,7 @@ class QTempGaussMC(VSObject):
 
             clip = reinterlace(matched, self.tff, self._apply_source_match) if self.tff.is_inter else matched
 
-            diff = self.input.std.MakeDiff(clip)
+            diff = self.bob_input.std.MakeDiff(clip)
             refine_bobbed = self._interpolate(diff, self.source_match_bobber)
             refine_matched = self._binomial_degrain(
                 refine_bobbed, self.source_match_tr, **self.source_match_degrain_args
@@ -1225,8 +1249,8 @@ class QTempGaussMC(VSObject):
             return clip
 
         fields_src = self.denoise_output.std.SeparateFields(self.tff.is_tff)
-        if self.is_repair:
-            fields_src = core.std.SelectEvery(fields_src, 4, (0, 3))
+        if self._is_repair:
+            fields_src = fields_src.std.SelectEvery(4, (0, 3))
         fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
 
         woven = reweave(fields_src, fields_flt, self.tff.field, self._apply_lossless)
@@ -1258,8 +1282,8 @@ class QTempGaussMC(VSObject):
                 resharp = norm_expr(
                     [clip, source_min, source_max],
                     "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
-                    dark_offset=scale_delta(dark_offset, 8, clip),
-                    bright_offset=scale_delta(bright_offset, 8, clip),
+                    dark_offset=scale_delta(dark_offset, 8, self.clip),
+                    bright_offset=scale_delta(bright_offset, 8, self.clip),
                     func=self._apply_sharpen,
                 )
 
@@ -1272,7 +1296,7 @@ class QTempGaussMC(VSObject):
 
         if self.sharpen_thin:
             median_diff = norm_expr(
-                [clip, median_blur(clip, mode=ConvMode.VERTICAL)],
+                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self._apply_sharpen)],
                 "y x - {thin} * neutral +",
                 thin=self.sharpen_thin,
                 func=self._apply_sharpen,
@@ -1280,7 +1304,7 @@ class QTempGaussMC(VSObject):
             blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self._apply_sharpen)
 
             resharp = norm_expr(
-                [resharp, BlurMatrix.BINOMIAL()(blurred_diff), blurred_diff],
+                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self._apply_sharpen), blurred_diff],
                 "y neutral - dup abs z neutral - abs > swap x + x ?",
                 func=self._apply_sharpen,
             )
@@ -1288,49 +1312,44 @@ class QTempGaussMC(VSObject):
         return resharp
 
     def _apply_back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
-        if self.sharpen_strength or self.sharpen_thin:
-            flt = src.std.MergeDiff(gauss_blur(flt.std.MakeDiff(src), self.backblend_sigma))
-
-        return flt
+        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.backblend_sigma))
 
     def _apply_sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
+        if not self._sharpness_limiting_enabled:
+            return clip
+
         undershoot, overshoot = self.sharpen_limit_clamp
 
-        if self.sharpen_strength or self.sharpen_thin:
-            if self.sharpen_limit_mode in {
-                self.SharpenLimitMode.SPATIAL_PRESMOOTH,
-                self.SharpenLimitMode.SPATIAL_POSTSMOOTH,
-            }:
-                if self.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
-                    clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
-                else:
-                    inpand = Morpho.minimum(
-                        self.bobbed, iterations=self.sharpen_limit_radius, func=self._apply_sharpen_limit
-                    )
-                    expand = Morpho.maximum(
-                        self.bobbed, iterations=self.sharpen_limit_radius, func=self._apply_sharpen_limit
-                    )
-                    clip = norm_expr(
-                        [clip, inpand, expand],
-                        "x y {undershoot} - z {overshoot} + clamp",
-                        undershoot=undershoot,
-                        overshoot=overshoot,
-                        func=self._apply_sharpen_limit,
-                    )
-            elif self.sharpen_limit_mode in {
-                self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
-                self.SharpenLimitMode.TEMPORAL_POSTSMOOTH,
-            }:
-                clip = mc_clamp(
-                    clip,
-                    self.bobbed,
-                    self.mv,
-                    (undershoot, overshoot),
-                    self._apply_sharpen_limit,
-                    tr=self.sharpen_limit_radius,
-                    thscd=self.analyze_thscd,
-                    **self.sharpen_limit_comp_args,
+        if self.sharpen_limit_mode.is_spatial:
+            if self.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
+                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
+            else:
+                inpand = Morpho.minimum(
+                    self.bobbed, iterations=self.sharpen_limit_radius, func=self._apply_sharpen_limit
                 )
+                expand = Morpho.maximum(
+                    self.bobbed,
+                    iterations=self.sharpen_limit_radius,
+                    func=self._apply_sharpen_limit,
+                )
+                clip = norm_expr(
+                    [clip, inpand, expand],
+                    "x y {undershoot} - z {overshoot} + clamp",
+                    undershoot=scale_delta(undershoot, 8, self.clip),
+                    overshoot=scale_delta(overshoot, 8, self.clip),
+                    func=self._apply_sharpen_limit,
+                )
+        elif self.sharpen_limit_mode.is_temporal:
+            clip = mc_clamp(
+                clip,
+                self.bobbed,
+                self.mv,
+                (undershoot, overshoot),
+                self._apply_sharpen_limit,
+                tr=self.sharpen_limit_radius,
+                thscd=self.analyze_thscd,
+                **self.sharpen_limit_comp_args,
+            )
 
         return clip
 
@@ -1348,6 +1367,7 @@ class QTempGaussMC(VSObject):
                 self.basic_output,
                 tr=self.final_tr,
                 thsad=self.final_thsad,
+                thsad2=self.final_thsad2,
                 thscd=self.analyze_thscd,
                 **self.final_degrain_args,
             )
@@ -1355,12 +1375,9 @@ class QTempGaussMC(VSObject):
             smoothed = self.basic_output
 
         if smoothed is not self.bobbed:
-            smoothed = self._mask_shimmer(smoothed, self.bobbed, **self.final_mask_shimmer_args)
+            smoothed = mask_shimmer(smoothed, self.bobbed, **self.final_mask_shimmer_args, func=self._apply_final)
 
-        if self.sharpen_limit_mode in {
-            self.SharpenLimitMode.SPATIAL_POSTSMOOTH,
-            self.SharpenLimitMode.TEMPORAL_POSTSMOOTH,
-        }:
+        if self._sharpness_limiting_enabled and self.sharpen_limit_mode.is_postsmooth:
             smoothed = self._apply_sharpen_limit(smoothed)
 
         if self.lossless_mode == self.LosslessMode.POSTSMOOTH:
@@ -1369,12 +1386,14 @@ class QTempGaussMC(VSObject):
         self.final_output = self._apply_noise_restore(smoothed, self.final_noise_restore)
 
     def _apply_motion_blur(self) -> None:
-        angle_in, angle_out = self.motion_blur_shutter_angle
-        blur_level = (angle_out * self.motion_blur_fps_divisor - angle_in) * 100 / 360
+        blur_level = self._motion_blur_level
 
         if blur_level:
             blurred = self.mv.flow_blur(
-                self.final_output, blur=blur_level, thscd=self.analyze_thscd, **self.motion_blur_blur_args
+                self.final_output,
+                blur=blur_level,
+                thscd=self.analyze_thscd,
+                **self.motion_blur_blur_args,
             )
 
             if self.motion_blur_mask_args.get("ml", 0):
@@ -1389,35 +1408,19 @@ class QTempGaussMC(VSObject):
         else:
             blurred = self.final_output
 
-        if self.motion_blur_fps_divisor != 1:
+        if self._motion_blur_fps_divisor > 1:
             blurred = blurred[:: self.motion_blur_fps_divisor]
 
         self.motion_blur_output = blurred
 
     def _run_process(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, func: FuncExcept) -> vs.VideoNode:
-        attrs = (
-            "tff",
-            "is_repair",
-            "mv",
-            "clip",
-            "draft",
-            "input",
-            "bobbed",
-            "noise",
-            "prefilter_output",
-            "denoise_output",
-            "basic_output",
-            "final_output",
-            "motion_blur_output",
-        )
-
-        for attr in attrs:
+        for attr in QTempGaussMC.__annotations__:
             with suppress(AttributeError):
                 delattr(self, attr)
 
         self.clip = clip
         self.tff = FieldBased.from_param_or_video(tff, self.clip, True, func)
-        self.is_repair = func == self.repair
+        self.func = func
 
         if not self.tff.is_inter and func != self.deshimmer:
             raise UnsupportedFieldBasedError("This method is incompatible with progressive video!", func)
@@ -1430,16 +1433,6 @@ class QTempGaussMC(VSObject):
         self._apply_motion_blur()
 
         return self.motion_blur_output
-
-    @contextmanager
-    def _disable_fps_divisor(self) -> Generator[None]:
-        orig = self.motion_blur_fps_divisor
-        self.motion_blur_fps_divisor = 1
-
-        try:
-            yield
-        finally:
-            self.motion_blur_fps_divisor = orig
 
     def deinterlace(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
@@ -1462,7 +1455,7 @@ class QTempGaussMC(VSObject):
         Bob interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is
         ignored.
 
-        Interpolates missing fields to reconstruct double-framerate progressive frames.
+        Interpolates missing fields to reconstruct progressive frames.
 
         Args:
             clip: Clip to process.
@@ -1471,14 +1464,13 @@ class QTempGaussMC(VSObject):
         Returns:
             Bobbed clip.
         """
-        with self._disable_fps_divisor():
-            return self._run_process(clip, tff, self.bob)
+        return self._run_process(clip, tff, self.bob)
 
     def repair(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
         Repair badly deinterlaced input.
 
-        Drops half the fields to recreate an interlaced stream using the remaining ones.
+        Drops half the fields to recreate an interlaced clip using the remaining ones.
 
         Args:
             clip: Clip to process.
@@ -1502,3 +1494,65 @@ class QTempGaussMC(VSObject):
             Deshimmered clip.
         """
         return self._run_process(clip, FieldBased.PROGRESSIVE, self.deshimmer)
+
+
+def mask_shimmer(
+    flt: vs.VideoNode,
+    src: vs.VideoNode,
+    erosion_distance: int = 4,
+    over_dilation: int = 0,
+    func: FuncExcept | None = None,
+) -> vs.VideoNode:
+    """
+    Removes areas of difference between a temporally blurred clip and a reference clip that are not due to
+    bob shimmer by only allowing thin horizontal areas of difference.
+
+    High-level overview:
+        - Vertical morphological analysis: Extracts the difference between source and filtered clips, running
+            vertical opening and closing operations to collapse thin bob shimmer while leaving large motion
+            artifacts intact.
+        - Safety margin adjustment: Applies extra dilation passes to fine-tune detection boundaries on soft sources,
+            ensuring proper mask coverage on blurry edges.
+
+    Args:
+        flt: Filtered clip to perform masking on.
+        src: Source clip to restore from.
+        erosion_distance: Vertical radius for shimmer detection. Larger values capture more spread-out shimmer artifacts
+            on soft sources. Defaults to 4.
+        over_dilation: Extra dilation passes for safety margins. Larger values shrink the mask boundary to avoid
+            artifacts on blurry edges. Defaults to 0.
+        func: Function returned for custom error handling. This should only be set by VS package developers. Defaults to
+            None.
+    """
+    func = func or mask_shimmer
+
+    if not erosion_distance:
+        return flt
+
+    ed_pos = 1 + erosion_distance // 3
+    ed_neg = (erosion_distance + 4) // 3
+    ed_res = erosion_distance % 3
+    od_pos, od_neg = divmod(over_dilation, 3)
+
+    ops = ((Morpho.maximum, Morpho.inflate), (Morpho.minimum, Morpho.deflate))
+
+    diff = src.std.MakeDiff(flt)
+
+    processed = list[vs.VideoNode]()
+    for (grow_op, inflate_op), (shrink_op, deflate_op) in (ops, ops[::-1]):
+        clip = grow_op(diff, iterations=ed_pos, coords=Coordinates.VERTICAL, func=func)
+
+        if ed_res:
+            clip = inflate_op(clip, func=func)
+            if ed_res == 2:
+                clip = median_blur(clip, func=func)
+
+        clip = shrink_op(clip, iterations=ed_neg, coords=Coordinates.VERTICAL, func=func)
+
+        if over_dilation:
+            clip = shrink_op(clip, iterations=od_pos, func=func)
+            clip = deflate_op(clip, iterations=od_neg, func=func)
+
+        processed.append(clip)
+
+    return norm_expr([flt, diff, *processed], "x y z neutral min a neutral max clamp neutral - +", func=func)

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1,5 +1,4 @@
 from collections.abc import Mapping
-from contextlib import suppress
 from copy import deepcopy
 from enum import auto
 from math import comb
@@ -77,7 +76,7 @@ class QTGMCArgs:
 
     class Degrain(TypedDict, total=False):
         """
-        Arguments accepted by the internal `_binomial_degrain` method, calling
+        Arguments accepted by the internal `binomial_degrain` method, calling
         [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain] through
         [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
         [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match], or directly through
@@ -281,22 +280,20 @@ class _QTGMCBuilder:
 
         High-level overview:
             - ([QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]) Draft bobbed clip generation:
-                Begins with simple spatial interpolation to produce
-                [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft], which inherently contains severe temporal
-                instability known as bob shimmer.
+                Begins with simple spatial interpolation to produce the draft clip, which inherently contains severe
+                temporal instability known as bob shimmer.
             - ([QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]) Vertical spatial pre-filtering: Applies a
                 vertical binomial blur to filter out residual vertical artifacts.
             - Temporal binomial blurring: Applies a temporal binomial blur to smooth
-                [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft], removing the shimmer, which prevents
-                [MVTools][vsdenoise.mvtools.mvtools.MVTools] from falsely latching onto the shimmer as motion (though
-                this uncompensated blur introduces ghosting).
+                the draft clip, removing the shimmer, which prevents [MVTools][vsdenoise.mvtools.mvtools.MVTools] from
+                falsely latching onto the shimmer as motion (though this uncompensated blur introduces ghosting).
             - Shimmer masking: Uses a specialized masking process to eliminate the introduced ghosting while retaining
                 the shimmer removal.
             - Gaussian blurring post-processing: Applies Gaussian blurring to lower high SAD values caused by sharp
                 edges, ensuring edges are properly processed rather than skipped.
-            - Edge detail restoration: Conservatively restores essential edge detail from
-                [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft] back into the blurred clip via a limiting process
-                so [MVTools][vsdenoise.mvtools.mvtools.MVTools] retains the ability to track motion effectively.
+            - Edge detail restoration: Conservatively restores essential edge detail from the draft clip back into the
+                blurred clip via a limiting process so [MVTools][vsdenoise.mvtools.mvtools.MVTools] retains the ability
+                to track motion effectively.
             - Levels optimization:
                 Applies level adjustments to brighten dark regions and enhance contrast, enabling
                 [MVTools][vsdenoise.mvtools.mvtools.MVTools] to better track dark details, reducing downstream ghosting
@@ -315,9 +312,8 @@ class _QTGMCBuilder:
                 Defaults to (1.9, 0.9).
             limit: Tuple containing the 3-step limiting thresholds (8-bit) for the Gaussian blur post-processing:
 
-                   - First value: Maximum allowed delta between the temporally blurred clip and
-                   [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft]. Smaller values clamp
-                   [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft] closer to the temporally blurred clip.
+                   - First value: Maximum allowed delta between the temporally blurred clip and the draft clip. Smaller
+                    values clamp the draft clip closer to the temporally blurred clip.
                    - Second value: Tolerance threshold for the allowed difference between the clamped clip and the
                     Gaussian-blurred clip before hard clipping triggers. Larger values widen the allowed range for
                     smooth blending before hard clipping is enforced.
@@ -475,6 +471,18 @@ class _QTGMCBuilder:
 
         return self
 
+    @property
+    def _denoise_enabled(self) -> bool:
+        return self.denoise_full_denoise or self._noise_restore_enabled
+
+    @property
+    def _noise_restore_enabled(self) -> bool:
+        return bool(self.basic_noise_restore or self.final_noise_restore)
+
+    @property
+    def _stabilization_enabled(self) -> bool:
+        return self.denoise_stabilize is not False and self._noise_restore_enabled
+
     def basic(
         self,
         *,
@@ -493,15 +501,13 @@ class _QTGMCBuilder:
         Creates the basic output of the core algorithm. Intended to eliminate bob shimmer.
 
         High-level overview:
-            - High-quality bobbed clip generation: Begins with high-quality spatial interpolation to produce
-                [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], which inherently contains severe temporal
-                instability known as bob shimmer.
+            - High-quality bobbed clip generation: Begins with high-quality spatial interpolation to produce the bobbed
+                clip, which inherently contains severe temporal instability known as bob shimmer.
             - ([QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]) Motion SAD masking: Generates a motion-vector
-                SAD mask to blend [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] output over
-                [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], protecting static/low-motion detail.
+                SAD mask to blend [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] output over the bobbed
+                clip, protecting static/low-motion detail.
             - Motion-compensated temporal binomial smoothing: Applies a motion-compensated temporal binomial blur to
-                smooth [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], removing the shimmer while avoiding
-                ghosting artifacts.
+                smooth the bobbed clip, removing the shimmer while avoiding ghosting artifacts.
             - Shimmer masking: Uses a specialized masking process to eliminate the introduced blurring while retaining
                 the shimmer removal.
             - Additional refinements: Passes the temporally smoothed clip through optional fine-tuning processes:
@@ -525,7 +531,7 @@ class _QTGMCBuilder:
                 to None.
             bobber: Bobber to use for spatial interpolation. Defaults to NNEDI3(nsize=1).
             noise_restore: Amount of noise to restore after this stage. Used to retain stable noise. Defaults to 0.
-            degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
+            degrain_args: Additional arguments passed to the internal `binomial_degrain` call. Defaults to None.
             mask_args: Additional arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]. Only used
                 for [QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]. Defaults to {"ml": 10}.
             mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
@@ -589,7 +595,7 @@ class _QTGMCBuilder:
             similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
                 Defaults to 0.5.
             enhance: Enhances detail found by `iterations` > 1. Higher values exaggerate detail more. Defaults to 0.5.
-            degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
+            degrain_args: Additional arguments passed to the internal `binomial_degrain` call. Defaults to None.
         """
 
         self.source_match_tr = tr
@@ -615,6 +621,10 @@ class _QTGMCBuilder:
             self._source_match_bobber = deepcopy(value)
         else:
             self._source_match_bobber = Bobber.ensure_obj(value, self.__class__)
+
+    @property
+    def _source_match_enabled(self) -> bool:
+        return bool(self.source_match_iterations and self.basic_tr)
 
     def lossless(self, *, mode: LosslessMode = LosslessMode.NONE, anti_comb: bool = True) -> Self:
         """
@@ -681,6 +691,13 @@ class _QTGMCBuilder:
     def sharpen_strength(self, value: float | None) -> None:
         self._sharpen_strength = value
 
+    @property
+    def _sharpening_enabled(self) -> bool:
+        return bool(
+            (self.sharpen_strength or self.sharpen_thin)
+            and (self.back_blend_mode is self.BackBlendMode.NONE or self.back_blend_sigma)
+        )
+
     def back_blend(self, *, mode: BackBlendMode = BackBlendMode.BOTH, sigma: float = 1.4) -> Self:
         """
         Configures parameters for back-blending.
@@ -700,8 +717,8 @@ class _QTGMCBuilder:
                 sharpening more aggressively. Defaults to 1.4.
         """
 
-        self.backblend_mode = mode
-        self.backblend_sigma = sigma
+        self.back_blend_mode = mode
+        self.back_blend_sigma = sigma
 
         return self
 
@@ -722,9 +739,9 @@ class _QTGMCBuilder:
         High-level overview:
             - Sharpness limiting approaches:
                 - Spatial limiting: Clamps the sharpened clip's pixel values to the local spatial minimum and maximum
-                    bounds of [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed].
+                    bounds of the bobbed clip.
                 - Motion-compensated temporal limiting: Clamps the sharpened clip using motion-compensated reference
-                    frames from [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed].
+                    frames from the bobbed clip.
 
         Args:
             mode: How and when to apply limiting to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen]. Defaults
@@ -755,6 +772,14 @@ class _QTGMCBuilder:
     @sharpen_limit_mode.setter
     def sharpen_limit_mode(self, value: SharpenLimitMode | None) -> None:
         self._sharpen_limit_mode = value
+
+    @property
+    def _sharpness_limiting_enabled(self) -> bool:
+        return bool(
+            self.sharpen_limit_mode is not self.SharpenLimitMode.NONE
+            and self.sharpen_limit_radius
+            and self._sharpening_enabled
+        )
 
     def final(
         self,
@@ -848,36 +873,506 @@ class _QTGMCBuilder:
 
         return self
 
-    @property
-    def _denoise_enabled(self) -> bool:
-        return self.denoise_full_denoise or self._noise_restore_enabled
 
-    @property
-    def _noise_restore_enabled(self) -> bool:
-        return bool(self.basic_noise_restore or self.final_noise_restore)
+class _QTGMCRun:
+    class Mode(CustomIntEnum):
+        DEINTERLACE = auto()
+        BOB = auto()
+        REPAIR = auto()
+        DESHIMMER = auto()
 
-    @property
-    def _stabilization_enabled(self) -> bool:
-        return self.denoise_stabilize is not False and self._noise_restore_enabled
+    def __init__(
+        self,
+        clip: vs.VideoNode,
+        tff: FieldBasedLike | bool | None,
+        mode: Mode,
+        settings: _QTGMCBuilder,
+        func: FuncExcept,
+    ) -> None:
+        self.clip = clip
+        self.tff = FieldBased.from_param_or_video(tff, self.clip, True, func)
+        self.mode = mode
+        self.settings = settings
 
-    @property
-    def _source_match_enabled(self) -> bool:
-        return bool(self.source_match_iterations and self.basic_tr)
+        if not self.tff.is_inter and self.mode is not self.Mode.DESHIMMER:
+            raise UnsupportedFieldBasedError("This method is incompatible with progressive video!", func)
 
-    @property
-    def _sharpening_enabled(self) -> bool:
-        return bool(
-            (self.sharpen_strength or self.sharpen_thin)
-            and (self.backblend_mode == self.BackBlendMode.NONE or self.backblend_sigma)
+    @cachedproperty
+    def is_deinterlace(self) -> bool:
+        return self.tff.is_inter and not self.is_repair
+
+    @cachedproperty
+    def is_repair(self) -> bool:
+        return self.mode is self.Mode.REPAIR
+
+    @cachedproperty
+    def required_analyze_tr(self) -> int:
+        return max(
+            self.settings.analyze_force_tr,
+            self.settings.denoise_tr if self.settings.denoise_mc_denoise and self.settings._denoise_enabled else 0,
+            self.settings._stabilization_enabled,
+            self.settings.basic_tr,
+            self.repair_mask_enabled,
+            self.settings.source_match_tr
+            if self.settings.source_match_iterations > 1 and self.settings._source_match_enabled
+            else 0,
+            self.settings.sharpen_limit_radius
+            if self.settings.sharpen_limit_mode.is_temporal and self.settings._sharpness_limiting_enabled
+            else 0,
+            self.settings.final_tr,
+            bool(self.motion_blur_level),
         )
 
-    @property
-    def _sharpness_limiting_enabled(self) -> bool:
-        return bool(
-            self._sharpening_enabled
-            and self.sharpen_limit_mode != self.SharpenLimitMode.NONE
-            and self.sharpen_limit_radius
+    @cachedproperty
+    def repair_mask_enabled(self) -> bool:
+        return bool(self.is_repair and self.settings.basic_mask_args.get("ml", 0))
+
+    @cachedproperty
+    def motion_blur_level(self) -> float:
+        angle_in, angle_out = self.settings.motion_blur_shutter_angle
+
+        return (angle_out * self.motion_blur_fps_divisor - angle_in) * 100 / 360
+
+    @cachedproperty
+    def motion_blur_fps_divisor(self) -> int:
+        return 1 if self.mode is self.Mode.BOB else self.settings.motion_blur_fps_divisor
+
+    def interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
+        if self.tff.is_inter:
+            clip = bobber.bob(clip, tff=self.tff)
+
+        return clip
+
+    def binomial_degrain(self, clip: vs.VideoNode, tr: int, **degrain_args: Any) -> vs.VideoNode:
+        if not tr:
+            return clip
+
+        return self.mv.degrain(
+            clip,
+            tr=tr,
+            thsad=self.settings.basic_thsad,
+            thsad2=self.settings.basic_thsad2,
+            thscd=self.settings.analyze_thscd,
+            weights=BlurMatrix.BINOMIAL(radius=tr),
+            **degrain_args,
         )
+
+    def apply_prefilter(self) -> None:
+        if not (self.required_analyze_tr or self.settings._denoise_enabled):
+            return
+
+        self.draft = Catrom().bob(self.clip, tff=self.tff) if self.is_deinterlace else self.clip
+
+        if not self.required_analyze_tr or self.settings.analyze_vectors:
+            return
+
+        if self.is_repair:
+            search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self.apply_prefilter)
+        else:
+            search = self.draft
+
+        if self.settings.prefilter_tr:
+            smoothed = BlurMatrix.BINOMIAL(self.settings.prefilter_tr, mode=ConvMode.TEMPORAL)(
+                sc_detect(search, self.settings.prefilter_sc_threshold), scenechange=True, func=self.apply_prefilter
+            )
+            smoothed = mask_shimmer(
+                smoothed, search, **self.settings.prefilter_mask_shimmer_args, func=self.apply_prefilter
+            )
+        else:
+            smoothed = search
+
+        gauss_sigma, blend_weight = self.settings.prefilter_strength
+        lim1, lim2, lim3 = [scale_delta(thr, 8, self.clip) for thr in self.settings.prefilter_limit]
+        apply_blur = bool(gauss_sigma and blend_weight)
+
+        blurred = gauss_blur(smoothed, gauss_sigma) if apply_blur else smoothed
+
+        if apply_blur or (self.settings.prefilter_tr and lim1 and (lim2 or lim3)):
+            blurred = norm_expr(
+                [blurred, smoothed, search],
+                "y x y - {weight} * + BLUR! z y {lim1} - y {lim1} + clamp TWEAK! "
+                "BLUR@ {lim2} + TWEAK@ < BLUR@ {lim3} + BLUR@ {lim2} - TWEAK@ > BLUR@ {lim3} - "
+                "TWEAK@ BLUR@ TWEAK@ - {bias} * + ? ?",
+                weight=blend_weight,
+                lim1=lim1,
+                lim2=lim2,
+                lim3=lim3,
+                bias=self.settings.prefilter_bias,
+                func=self.apply_prefilter,
+            )
+
+        self.prefilter_output = prefilter_to_full_range(
+            blurred, func=self.apply_prefilter, **self.settings.prefilter_range_expansion_args
+        )
+
+    def apply_analyze(self) -> None:
+        if not self.required_analyze_tr:
+            return
+
+        blksize = self.settings.analyze_blksize
+        if not self.settings.analyze_vectors:
+            preset = {**self.settings.analyze_preset, "search_clip": self.prefilter_output}
+
+        self.mv = MVTools(self.draft, vectors=self.settings.analyze_vectors, **preset)
+
+        if not self.settings.analyze_vectors:
+            self.mv.analyze(tr=self.required_analyze_tr, blksize=blksize, overlap_div=self.settings.analyze_overlap)
+
+            for _ in range(self.settings.analyze_refine):
+                blksize = refine_blksize(blksize)
+                self.mv.recalculate(
+                    thsad=self.settings.analyze_thsad_recalc,
+                    blksize=blksize,
+                    overlap_div=self.settings.analyze_overlap,
+                )
+
+    def apply_denoise(self) -> None:
+        self.denoise_output = self.clip
+
+        if not self.settings._denoise_enabled:
+            return
+
+        if self.settings.denoise_mc_denoise and self.settings.denoise_tr:
+            denoised = self.mv.compensate(
+                tr=self.settings.denoise_tr,
+                thscd=self.settings.analyze_thscd,
+                temporal_func=lambda clip: self.settings.denoise_func(clip, tr=self.settings.denoise_tr),
+                **self.settings.denoise_func_comp_args,
+            )
+        else:
+            denoised = self.settings.denoise_func(self.draft, tr=self.settings.denoise_tr)
+
+        if self.is_deinterlace:
+            denoised = reinterlace(denoised, self.tff, self.apply_denoise)
+
+        if self.settings.denoise_full_denoise:
+            self.denoise_output = denoised
+
+        if not self.settings._noise_restore_enabled:
+            return
+
+        self.noise = self.clip.std.MakeDiff(denoised)
+
+        if self.is_deinterlace:
+            match self.settings.denoise_deint:
+                case self.settings.NoiseDeintMode.WEAVE:
+                    new_noise = self.noise.std.SeparateFields(self.tff.is_tff).std.DoubleWeave(self.tff.is_tff)
+                case self.settings.NoiseDeintMode.BOB:
+                    new_noise = Catrom().bob(self.noise, tff=self.tff)
+                case self.settings.NoiseDeintMode.GENERATE:
+                    noise_source = self.noise.std.SeparateFields(self.tff.is_tff)
+
+                    noise_max = Morpho.expand(noise_source, sw=2, sh=1, func=self.apply_denoise)
+                    noise_min = Morpho.inpand(noise_source, sw=2, sh=1, func=self.apply_denoise)
+
+                    gen_noise = Grainer.GAUSS(
+                        noise_source,
+                        ((0.5 * 255) / 3) ** 2,  # 3σ rule  # noqa: RUF003
+                        protect_edges=False,
+                        protect_neutral_chroma=False,
+                        neutral_out=True,
+                    )
+                    gen_noise = norm_expr(
+                        [noise_max, noise_min, gen_noise],
+                        "y x y - z neutral - range_size / 0.5 + * +",
+                        func=self.apply_denoise,
+                    )
+                    new_noise = reweave(noise_source, gen_noise, self.tff.field, self.apply_denoise)
+
+            self.noise = FieldBased.PROGRESSIVE.apply(new_noise)
+
+        if self.settings._stabilization_enabled:
+            noise_comp, _ = self.mv.compensate(
+                self.noise,
+                direction=MVDirection.BACKWARD,
+                tr=1,
+                thscd=self.settings.analyze_thscd,
+                interleave=False,
+                **self.settings.denoise_stabilize_comp_args,
+            )
+
+            self.noise = norm_expr(
+                [self.noise, *noise_comp],
+                "x neutral - abs y neutral - abs > x y ? dup x y + 2 / swap - {weight} * +",
+                weight=self.settings.denoise_stabilize,
+                func=self.apply_denoise,
+            )
+
+    def apply_basic(self) -> None:
+        if self.is_repair:
+            self.bob_input = reinterlace(self.denoise_output, self.tff, self.apply_basic)
+        else:
+            self.bob_input = self.denoise_output
+
+        self.bobbed = self.interpolate(self.bob_input, self.settings.basic_bobber)
+
+        if self.repair_mask_enabled:
+            mask = self.mv.mask(
+                direction=MVDirection.BACKWARD,
+                kind=MaskMode.SAD,
+                thscd=self.settings.analyze_thscd,
+                **self.settings.basic_mask_args,
+            )
+            self.bobbed = self.denoise_output.std.MaskedMerge(self.bobbed, mask)
+
+        smoothed = self.binomial_degrain(self.bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
+
+        if self.settings.basic_tr:
+            smoothed = mask_shimmer(
+                smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.apply_basic
+            )
+
+        if self.settings._source_match_enabled:
+            smoothed = self.apply_source_match(smoothed)
+
+        if self.settings.lossless_mode is self.settings.LosslessMode.PRESHARPEN:
+            smoothed = self.apply_lossless(smoothed)
+
+        if self.settings._sharpening_enabled:
+            resharp = self.apply_sharpen(smoothed)
+
+            if self.settings._sharpness_limiting_enabled and self.settings.sharpen_limit_mode.is_presmooth:
+                if self.settings.back_blend_mode in (
+                    self.settings.BackBlendMode.PRELIMIT,
+                    self.settings.BackBlendMode.BOTH,
+                ):
+                    resharp = self.apply_back_blend(resharp, smoothed)
+
+                resharp = self.apply_sharpen_limit(resharp)
+
+                if self.settings.back_blend_mode in (
+                    self.settings.BackBlendMode.POSTLIMIT,
+                    self.settings.BackBlendMode.BOTH,
+                ):
+                    resharp = self.apply_back_blend(resharp, smoothed)
+            elif self.settings.back_blend_mode is not self.settings.BackBlendMode.NONE:
+                resharp = self.apply_back_blend(resharp, smoothed)
+        else:
+            resharp = smoothed
+
+        self.basic_output = self.apply_noise_restore(resharp, self.settings.basic_noise_restore)
+
+    def apply_source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
+        def error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
+            if not tr:
+                return ref
+
+            tr_f = 2 * tr - 1
+            tr_s = 2**tr_f
+            binomial_coeff = comb(tr_f, tr)
+            error_adj = tr_s / (binomial_coeff + self.settings.source_match_similarity * (tr_s - binomial_coeff))
+
+            return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=error_adjustment)
+
+        if self.tff.is_inter:
+            clip = reinterlace(clip, self.tff, self.apply_source_match)
+
+        adjusted = error_adjustment(self.bob_input, clip, self.settings.basic_tr)
+        new_bobbed = self.interpolate(adjusted, self.settings.basic_bobber)
+        matched = self.binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
+
+        if self.settings.source_match_iterations > 1:
+            if self.settings.source_match_enhance:
+                matched = unsharpen(
+                    matched,
+                    self.settings.source_match_enhance,
+                    BlurMatrix.BINOMIAL(),
+                    func=self.apply_source_match,
+                )
+
+            clip = reinterlace(matched, self.tff, self.apply_source_match) if self.tff.is_inter else matched
+
+            diff = self.bob_input.std.MakeDiff(clip)
+            refine_bobbed = self.interpolate(diff, self.settings.source_match_bobber)
+            refine_matched = self.binomial_degrain(
+                refine_bobbed, self.settings.source_match_tr, **self.settings.source_match_degrain_args
+            )
+
+            if self.settings.source_match_iterations > 2:
+                refine_adjusted = error_adjustment(refine_bobbed, refine_matched, self.settings.source_match_tr)
+                refine_matched = self.binomial_degrain(
+                    refine_adjusted, self.settings.source_match_tr, **self.settings.source_match_degrain_args
+                )
+
+            return matched.std.MergeDiff(refine_matched)
+
+        return matched
+
+    def apply_lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
+        if not self.tff.is_inter or clip is self.bobbed:
+            return clip
+
+        fields_src = self.denoise_output.std.SeparateFields(self.tff.is_tff)
+        if self.is_repair:
+            fields_src = fields_src.std.SelectEvery(4, (0, 3))
+        fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
+
+        woven = reweave(fields_src, fields_flt, self.tff.field, self.apply_lossless)
+
+        if self.settings.lossless_anti_comb:
+            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self.apply_lossless).std.MakeDiff(woven)
+            fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
+
+            cleaned_diff = norm_expr(
+                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self.apply_lossless), fields_diff],
+                "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
+                func=self.apply_lossless,
+            )
+            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
+            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self.apply_lossless)
+
+        return FieldBased.PROGRESSIVE.apply(woven)
+
+    def apply_sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
+        resharp = clip
+
+        if self.settings.sharpen_strength:
+            if self.settings.sharpen_offset is not False:
+                dark_offset, bright_offset = self.settings.sharpen_offset
+
+                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self.apply_sharpen)
+                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self.apply_sharpen)
+
+                resharp = norm_expr(
+                    [clip, source_min, source_max],
+                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
+                    dark_offset=scale_delta(dark_offset, 8, self.clip),
+                    bright_offset=scale_delta(bright_offset, 8, self.clip),
+                    func=self.apply_sharpen,
+                )
+
+            resharp = unsharpen(
+                clip,
+                self.settings.sharpen_strength,
+                BlurMatrix.BINOMIAL()(resharp, func=self.apply_sharpen),
+                func=self.apply_sharpen,
+            )
+
+        if self.settings.sharpen_thin:
+            median_diff = norm_expr(
+                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self.apply_sharpen)],
+                "y x - {thin} * neutral +",
+                thin=self.settings.sharpen_thin,
+                func=self.apply_sharpen,
+            )
+            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self.apply_sharpen)
+
+            resharp = norm_expr(
+                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self.apply_sharpen), blurred_diff],
+                "y neutral - dup abs z neutral - abs > swap x + x ?",
+                func=self.apply_sharpen,
+            )
+
+        return resharp
+
+    def apply_back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
+        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_sigma))
+
+    def apply_sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
+        undershoot, overshoot = self.settings.sharpen_limit_clamp
+
+        if self.settings.sharpen_limit_mode.is_spatial:
+            if self.settings.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
+                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
+            else:
+                inpand = Morpho.minimum(
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self.apply_sharpen_limit
+                )
+                expand = Morpho.maximum(
+                    self.bobbed,
+                    iterations=self.settings.sharpen_limit_radius,
+                    func=self.apply_sharpen_limit,
+                )
+                clip = norm_expr(
+                    [clip, inpand, expand],
+                    "x y {undershoot} - z {overshoot} + clamp",
+                    undershoot=scale_delta(undershoot, 8, self.clip),
+                    overshoot=scale_delta(overshoot, 8, self.clip),
+                    func=self.apply_sharpen_limit,
+                )
+        elif self.settings.sharpen_limit_mode.is_temporal:
+            clip = mc_clamp(
+                clip,
+                self.bobbed,
+                self.mv,
+                (undershoot, overshoot),
+                self.apply_sharpen_limit,
+                tr=self.settings.sharpen_limit_radius,
+                thscd=self.settings.analyze_thscd,
+                **self.settings.sharpen_limit_comp_args,
+            )
+
+        return clip
+
+    def apply_noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
+        if restore:
+            clip = norm_expr(
+                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self.apply_noise_restore
+            )
+
+        return clip
+
+    def apply_final(self) -> None:
+        if self.settings.final_tr:
+            smoothed = self.mv.degrain(
+                self.basic_output,
+                tr=self.settings.final_tr,
+                thsad=self.settings.final_thsad,
+                thsad2=self.settings.final_thsad2,
+                thscd=self.settings.analyze_thscd,
+                **self.settings.final_degrain_args,
+            )
+        else:
+            smoothed = self.basic_output
+
+        if smoothed is not self.bobbed:
+            smoothed = mask_shimmer(
+                smoothed, self.bobbed, **self.settings.final_mask_shimmer_args, func=self.apply_final
+            )
+
+        if self.settings._sharpness_limiting_enabled and self.settings.sharpen_limit_mode.is_postsmooth:
+            smoothed = self.apply_sharpen_limit(smoothed)
+
+        if self.settings.lossless_mode is self.settings.LosslessMode.POSTSMOOTH:
+            smoothed = self.apply_lossless(smoothed)
+
+        self.final_output = self.apply_noise_restore(smoothed, self.settings.final_noise_restore)
+
+    def apply_motion_blur(self) -> None:
+        if self.motion_blur_level:
+            blurred = self.mv.flow_blur(
+                self.final_output,
+                blur=self.motion_blur_level,
+                thscd=self.settings.analyze_thscd,
+                **self.settings.motion_blur_blur_args,
+            )
+
+            if self.settings.motion_blur_mask_args.get("ml", 0):
+                mask = self.mv.mask(
+                    direction=MVDirection.BACKWARD,
+                    kind=MaskMode.VECTOR_LENGTH,
+                    thscd=self.settings.analyze_thscd,
+                    **self.settings.motion_blur_mask_args,
+                )
+
+                blurred = self.final_output.std.MaskedMerge(blurred, mask)
+        else:
+            blurred = self.final_output
+
+        if self.motion_blur_fps_divisor > 1:
+            blurred = blurred[:: self.motion_blur_fps_divisor]
+
+        self.motion_blur_output = blurred
+
+    def run(self) -> vs.VideoNode:
+        self.apply_prefilter()
+        self.apply_analyze()
+        self.apply_denoise()
+        self.apply_basic()
+        self.apply_final()
+        self.apply_motion_blur()
+
+        return self.motion_blur_output
 
 
 class QTempGaussMC(_QTGMCBuilder, VSObject):
@@ -891,548 +1386,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
     Originally based on TempGaussMC by Didée.
 
     Basic usage: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
-
-    Alternate documentation reference: [AviSynth documentation](http://avisynth.nl/index.php/QTGMC)
     """
-
-    func: FuncExcept
-    """Processing method in use."""
-
-    mv: MVTools
-    """
-    [MVTools][vsdenoise.mvtools.mvtools.MVTools] instance used during processing.
-
-    Only available after processing a clip that requires motion analysis.
-    """
-
-    tff: FieldBased
-    """Field order used during processing."""
-
-    clip: vs.VideoNode
-    """Clip to process."""
-
-    draft: vs.VideoNode
-    """
-    Draft processed clip, used as a base for [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter] and
-    [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
-
-    Only available after processing a clip that requires motion-vector processing or denoising.
-    """
-
-    bob_input: vs.VideoNode
-    """
-    Prepared input clip for high-quality interpolation. Used as a base for the internal `_interpolate` method and as a
-    reference for [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
-    """
-
-    bobbed: vs.VideoNode
-    """
-    High-quality bobbed clip, acting as a spatial interpolation base for
-    [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
-    [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
-    """
-
-    noise: vs.VideoNode
-    """
-    Noise extracted by [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
-
-    Only available after processing a clip that requires noise restoration.
-    """
-
-    prefilter_output: vs.VideoNode
-    """
-    Output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter].
-
-    Only available after processing a clip that requires internally generated motion vectors.
-    """
-
-    denoise_output: vs.VideoNode
-    """Output of [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
-
-    basic_output: vs.VideoNode
-    """Output of [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]."""
-
-    final_output: vs.VideoNode
-    """Output of [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final]."""
-
-    motion_blur_output: vs.VideoNode
-    """Output of [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur]."""
-
-    @property
-    def _is_deinterlace(self) -> bool:
-        return self.tff.is_inter and not self._is_repair
-
-    @property
-    def _is_repair(self) -> bool:
-        return self.func == self.repair
-
-    @property
-    def _required_analyze_tr(self) -> int:
-        return max(
-            self.analyze_force_tr,
-            self.denoise_tr if self.denoise_mc_denoise and self._denoise_enabled else 0,
-            self._stabilization_enabled,
-            self.basic_tr,
-            self._repair_mask_enabled,
-            self.source_match_tr if self.source_match_iterations > 1 and self._source_match_enabled else 0,
-            self.sharpen_limit_radius
-            if self.sharpen_limit_mode.is_temporal and self._sharpness_limiting_enabled
-            else 0,
-            self.final_tr,
-            bool(self._motion_blur_level),
-        )
-
-    @property
-    def _repair_mask_enabled(self) -> bool:
-        return bool(self._is_repair and self.basic_mask_args.get("ml", 0))
-
-    @property
-    def _motion_blur_level(self) -> float:
-        angle_in, angle_out = self.motion_blur_shutter_angle
-
-        return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
-
-    @property
-    def _motion_blur_fps_divisor(self) -> int:
-        return 1 if self.func == self.bob else self.motion_blur_fps_divisor
-
-    def _interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
-        if self.tff.is_inter:
-            clip = bobber.bob(clip, tff=self.tff)
-
-        return clip
-
-    def _binomial_degrain(self, clip: vs.VideoNode, tr: int, **degrain_args: Any) -> vs.VideoNode:
-        if not tr:
-            return clip
-
-        return self.mv.degrain(
-            clip,
-            tr=tr,
-            thsad=self.basic_thsad,
-            thsad2=self.basic_thsad2,
-            thscd=self.analyze_thscd,
-            weights=BlurMatrix.BINOMIAL(radius=tr),
-            **degrain_args,
-        )
-
-    def _apply_prefilter(self) -> None:
-        analyze_tr = self._required_analyze_tr
-
-        if not (analyze_tr or self._denoise_enabled):
-            return
-
-        self.draft = Catrom().bob(self.clip, tff=self.tff) if self._is_deinterlace else self.clip
-
-        if not analyze_tr or self.analyze_vectors:
-            return
-
-        if self._is_repair:
-            search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self._apply_prefilter)
-        else:
-            search = self.draft
-
-        if self.prefilter_tr:
-            smoothed = BlurMatrix.BINOMIAL(self.prefilter_tr, mode=ConvMode.TEMPORAL)(
-                sc_detect(search, self.prefilter_sc_threshold), scenechange=True, func=self._apply_prefilter
-            )
-            smoothed = mask_shimmer(smoothed, search, **self.prefilter_mask_shimmer_args, func=self._apply_prefilter)
-        else:
-            smoothed = search
-
-        gauss_sigma, blend_weight = self.prefilter_strength
-        lim1, lim2, lim3 = [scale_delta(thr, 8, self.clip) for thr in self.prefilter_limit]
-        apply_blur = bool(gauss_sigma and blend_weight)
-
-        blurred = gauss_blur(smoothed, gauss_sigma) if apply_blur else smoothed
-
-        if apply_blur or (self.prefilter_tr and lim1 and (lim2 or lim3)):
-            blurred = norm_expr(
-                [blurred, smoothed, search],
-                "y x y - {weight} * + BLUR! z y {lim1} - y {lim1} + clamp TWEAK! "
-                "BLUR@ {lim2} + TWEAK@ < BLUR@ {lim3} + BLUR@ {lim2} - TWEAK@ > BLUR@ {lim3} - "
-                "TWEAK@ BLUR@ TWEAK@ - {bias} * + ? ?",
-                weight=blend_weight,
-                lim1=lim1,
-                lim2=lim2,
-                lim3=lim3,
-                bias=self.prefilter_bias,
-                func=self._apply_prefilter,
-            )
-
-        self.prefilter_output = prefilter_to_full_range(
-            blurred, func=self._apply_prefilter, **self.prefilter_range_expansion_args
-        )
-
-    def _apply_analyze(self) -> None:
-        tr = self._required_analyze_tr
-
-        if not tr:
-            return
-
-        blksize = self.analyze_blksize
-        if not self.analyze_vectors:
-            preset = {**self.analyze_preset, "search_clip": self.prefilter_output}
-
-        self.mv = MVTools(self.draft, vectors=self.analyze_vectors, **preset)
-
-        if not self.analyze_vectors:
-            self.mv.analyze(tr=tr, blksize=blksize, overlap_div=self.analyze_overlap)
-
-            for _ in range(self.analyze_refine):
-                blksize = refine_blksize(blksize)
-                self.mv.recalculate(thsad=self.analyze_thsad_recalc, blksize=blksize, overlap_div=self.analyze_overlap)
-
-    def _apply_denoise(self) -> None:
-        self.denoise_output = self.clip
-
-        if not self._denoise_enabled:
-            return
-
-        if self.denoise_mc_denoise and self.denoise_tr:
-            denoised = self.mv.compensate(
-                tr=self.denoise_tr,
-                thscd=self.analyze_thscd,
-                temporal_func=lambda clip: self.denoise_func(clip, tr=self.denoise_tr),
-                **self.denoise_func_comp_args,
-            )
-        else:
-            denoised = self.denoise_func(self.draft, tr=self.denoise_tr)
-
-        if self._is_deinterlace:
-            denoised = reinterlace(denoised, self.tff, self._apply_denoise)
-
-        if self.denoise_full_denoise:
-            self.denoise_output = denoised
-
-        if not self._noise_restore_enabled:
-            return
-
-        self.noise = self.clip.std.MakeDiff(denoised)
-
-        if self._is_deinterlace:
-            match self.denoise_deint:
-                case self.NoiseDeintMode.WEAVE:
-                    new_noise = self.noise.std.SeparateFields(self.tff.is_tff).std.DoubleWeave(self.tff.is_tff)
-                case self.NoiseDeintMode.BOB:
-                    new_noise = Catrom().bob(self.noise, tff=self.tff)
-                case self.NoiseDeintMode.GENERATE:
-                    noise_source = self.noise.std.SeparateFields(self.tff.is_tff)
-
-                    noise_max = Morpho.expand(noise_source, sw=2, sh=1, func=self._apply_denoise)
-                    noise_min = Morpho.inpand(noise_source, sw=2, sh=1, func=self._apply_denoise)
-
-                    gen_noise = Grainer.GAUSS(
-                        noise_source,
-                        ((0.5 * 255) / 3) ** 2,  # 3σ rule  # noqa: RUF003
-                        protect_edges=False,
-                        protect_neutral_chroma=False,
-                        neutral_out=True,
-                    )
-                    gen_noise = norm_expr(
-                        [noise_max, noise_min, gen_noise],
-                        "y x y - z neutral - range_size / 0.5 + * +",
-                        func=self._apply_denoise,
-                    )
-                    new_noise = reweave(noise_source, gen_noise, self.tff.field, self._apply_denoise)
-
-            self.noise = FieldBased.PROGRESSIVE.apply(new_noise)
-
-        if self._stabilization_enabled:
-            noise_comp, _ = self.mv.compensate(
-                self.noise,
-                direction=MVDirection.BACKWARD,
-                tr=1,
-                thscd=self.analyze_thscd,
-                interleave=False,
-                **self.denoise_stabilize_comp_args,
-            )
-
-            self.noise = norm_expr(
-                [self.noise, *noise_comp],
-                "x neutral - abs y neutral - abs > x y ? dup x y + 2 / swap - {weight} * +",
-                weight=self.denoise_stabilize,
-                func=self._apply_denoise,
-            )
-
-    def _apply_basic(self) -> None:
-        if self._is_repair:
-            self.bob_input = reinterlace(self.denoise_output, self.tff, self._apply_basic)
-        else:
-            self.bob_input = self.denoise_output
-
-        self.bobbed = self._interpolate(self.bob_input, self.basic_bobber)
-
-        if self._repair_mask_enabled:
-            mask = self.mv.mask(
-                direction=MVDirection.BACKWARD,
-                kind=MaskMode.SAD,
-                thscd=self.analyze_thscd,
-                **self.basic_mask_args,
-            )
-            self.bobbed = self.denoise_output.std.MaskedMerge(self.bobbed, mask)
-
-        smoothed = self._binomial_degrain(self.bobbed, self.basic_tr, **self.basic_degrain_args)
-
-        if self.basic_tr:
-            smoothed = mask_shimmer(smoothed, self.bobbed, **self.basic_mask_shimmer_args, func=self._apply_basic)
-
-        if self._source_match_enabled:
-            smoothed = self._apply_source_match(smoothed)
-
-        if self.lossless_mode == self.LosslessMode.PRESHARPEN:
-            smoothed = self._apply_lossless(smoothed)
-
-        if self._sharpening_enabled:
-            resharp = self._apply_sharpen(smoothed)
-
-            if self._sharpness_limiting_enabled and self.sharpen_limit_mode.is_presmooth:
-                if self.backblend_mode in (self.BackBlendMode.PRELIMIT, self.BackBlendMode.BOTH):
-                    resharp = self._apply_back_blend(resharp, smoothed)
-
-                resharp = self._apply_sharpen_limit(resharp)
-
-                if self.backblend_mode in (self.BackBlendMode.POSTLIMIT, self.BackBlendMode.BOTH):
-                    resharp = self._apply_back_blend(resharp, smoothed)
-            elif self.backblend_mode != self.BackBlendMode.NONE:
-                resharp = self._apply_back_blend(resharp, smoothed)
-        else:
-            resharp = smoothed
-
-        self.basic_output = self._apply_noise_restore(resharp, self.basic_noise_restore)
-
-    def _apply_source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
-        def _error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
-            if not tr:
-                return ref
-
-            tr_f = 2 * tr - 1
-            tr_s = 2**tr_f
-            binomial_coeff = comb(tr_f, tr)
-            error_adj = tr_s / (binomial_coeff + self.source_match_similarity * (tr_s - binomial_coeff))
-
-            return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=_error_adjustment)
-
-        if self.tff.is_inter:
-            clip = reinterlace(clip, self.tff, self._apply_source_match)
-
-        adjusted = _error_adjustment(self.bob_input, clip, self.basic_tr)
-        new_bobbed = self._interpolate(adjusted, self.basic_bobber)
-        matched = self._binomial_degrain(new_bobbed, self.basic_tr, **self.basic_degrain_args)
-
-        if self.source_match_iterations > 1:
-            if self.source_match_enhance:
-                matched = unsharpen(
-                    matched, self.source_match_enhance, BlurMatrix.BINOMIAL(), func=self._apply_source_match
-                )
-
-            clip = reinterlace(matched, self.tff, self._apply_source_match) if self.tff.is_inter else matched
-
-            diff = self.bob_input.std.MakeDiff(clip)
-            refine_bobbed = self._interpolate(diff, self.source_match_bobber)
-            refine_matched = self._binomial_degrain(
-                refine_bobbed, self.source_match_tr, **self.source_match_degrain_args
-            )
-
-            if self.source_match_iterations > 2:
-                refine_adjusted = _error_adjustment(refine_bobbed, refine_matched, self.source_match_tr)
-                refine_matched = self._binomial_degrain(
-                    refine_adjusted, self.source_match_tr, **self.source_match_degrain_args
-                )
-
-            return matched.std.MergeDiff(refine_matched)
-
-        return matched
-
-    def _apply_lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
-        if not self.tff.is_inter or clip is self.bobbed:
-            return clip
-
-        fields_src = self.denoise_output.std.SeparateFields(self.tff.is_tff)
-        if self._is_repair:
-            fields_src = fields_src.std.SelectEvery(4, (0, 3))
-        fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
-
-        woven = reweave(fields_src, fields_flt, self.tff.field, self._apply_lossless)
-
-        if self.lossless_anti_comb:
-            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self._apply_lossless).std.MakeDiff(woven)
-            fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
-
-            cleaned_diff = norm_expr(
-                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self._apply_lossless), fields_diff],
-                "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
-                func=self._apply_lossless,
-            )
-            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
-            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self._apply_lossless)
-
-        return FieldBased.PROGRESSIVE.apply(woven)
-
-    def _apply_sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
-        resharp = clip
-
-        if self.sharpen_strength:
-            if self.sharpen_offset is not False:
-                dark_offset, bright_offset = self.sharpen_offset
-
-                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self._apply_sharpen)
-                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self._apply_sharpen)
-
-                resharp = norm_expr(
-                    [clip, source_min, source_max],
-                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
-                    dark_offset=scale_delta(dark_offset, 8, self.clip),
-                    bright_offset=scale_delta(bright_offset, 8, self.clip),
-                    func=self._apply_sharpen,
-                )
-
-            resharp = unsharpen(
-                clip,
-                self.sharpen_strength,
-                BlurMatrix.BINOMIAL()(resharp, func=self._apply_sharpen),
-                func=self._apply_sharpen,
-            )
-
-        if self.sharpen_thin:
-            median_diff = norm_expr(
-                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self._apply_sharpen)],
-                "y x - {thin} * neutral +",
-                thin=self.sharpen_thin,
-                func=self._apply_sharpen,
-            )
-            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self._apply_sharpen)
-
-            resharp = norm_expr(
-                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self._apply_sharpen), blurred_diff],
-                "y neutral - dup abs z neutral - abs > swap x + x ?",
-                func=self._apply_sharpen,
-            )
-
-        return resharp
-
-    def _apply_back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
-        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.backblend_sigma))
-
-    def _apply_sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
-        if not self._sharpness_limiting_enabled:
-            return clip
-
-        undershoot, overshoot = self.sharpen_limit_clamp
-
-        if self.sharpen_limit_mode.is_spatial:
-            if self.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
-                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
-            else:
-                inpand = Morpho.minimum(
-                    self.bobbed, iterations=self.sharpen_limit_radius, func=self._apply_sharpen_limit
-                )
-                expand = Morpho.maximum(
-                    self.bobbed,
-                    iterations=self.sharpen_limit_radius,
-                    func=self._apply_sharpen_limit,
-                )
-                clip = norm_expr(
-                    [clip, inpand, expand],
-                    "x y {undershoot} - z {overshoot} + clamp",
-                    undershoot=scale_delta(undershoot, 8, self.clip),
-                    overshoot=scale_delta(overshoot, 8, self.clip),
-                    func=self._apply_sharpen_limit,
-                )
-        elif self.sharpen_limit_mode.is_temporal:
-            clip = mc_clamp(
-                clip,
-                self.bobbed,
-                self.mv,
-                (undershoot, overshoot),
-                self._apply_sharpen_limit,
-                tr=self.sharpen_limit_radius,
-                thscd=self.analyze_thscd,
-                **self.sharpen_limit_comp_args,
-            )
-
-        return clip
-
-    def _apply_noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
-        if restore:
-            clip = norm_expr(
-                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self._apply_noise_restore
-            )
-
-        return clip
-
-    def _apply_final(self) -> None:
-        if self.final_tr:
-            smoothed = self.mv.degrain(
-                self.basic_output,
-                tr=self.final_tr,
-                thsad=self.final_thsad,
-                thsad2=self.final_thsad2,
-                thscd=self.analyze_thscd,
-                **self.final_degrain_args,
-            )
-        else:
-            smoothed = self.basic_output
-
-        if smoothed is not self.bobbed:
-            smoothed = mask_shimmer(smoothed, self.bobbed, **self.final_mask_shimmer_args, func=self._apply_final)
-
-        if self._sharpness_limiting_enabled and self.sharpen_limit_mode.is_postsmooth:
-            smoothed = self._apply_sharpen_limit(smoothed)
-
-        if self.lossless_mode == self.LosslessMode.POSTSMOOTH:
-            smoothed = self._apply_lossless(smoothed)
-
-        self.final_output = self._apply_noise_restore(smoothed, self.final_noise_restore)
-
-    def _apply_motion_blur(self) -> None:
-        blur_level = self._motion_blur_level
-
-        if blur_level:
-            blurred = self.mv.flow_blur(
-                self.final_output,
-                blur=blur_level,
-                thscd=self.analyze_thscd,
-                **self.motion_blur_blur_args,
-            )
-
-            if self.motion_blur_mask_args.get("ml", 0):
-                mask = self.mv.mask(
-                    direction=MVDirection.BACKWARD,
-                    kind=MaskMode.VECTOR_LENGTH,
-                    thscd=self.analyze_thscd,
-                    **self.motion_blur_mask_args,
-                )
-
-                blurred = self.final_output.std.MaskedMerge(blurred, mask)
-        else:
-            blurred = self.final_output
-
-        if self._motion_blur_fps_divisor > 1:
-            blurred = blurred[:: self.motion_blur_fps_divisor]
-
-        self.motion_blur_output = blurred
-
-    def _run_process(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, func: FuncExcept) -> vs.VideoNode:
-        for attr in QTempGaussMC.__annotations__:
-            with suppress(AttributeError):
-                delattr(self, attr)
-
-        self.clip = clip
-        self.tff = FieldBased.from_param_or_video(tff, self.clip, True, func)
-        self.func = func
-
-        if not self.tff.is_inter and func != self.deshimmer:
-            raise UnsupportedFieldBasedError("This method is incompatible with progressive video!", func)
-
-        self._apply_prefilter()
-        self._apply_analyze()
-        self._apply_denoise()
-        self._apply_basic()
-        self._apply_final()
-        self._apply_motion_blur()
-
-        return self.motion_blur_output
 
     def deinterlace(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
@@ -1448,7 +1402,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Deinterlaced clip.
         """
-        return self._run_process(clip, tff, self.deinterlace)
+        return _QTGMCRun(clip, tff, _QTGMCRun.Mode.DEINTERLACE, self, self.deinterlace).run()
 
     def bob(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
@@ -1464,7 +1418,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Bobbed clip.
         """
-        return self._run_process(clip, tff, self.bob)
+        return _QTGMCRun(clip, tff, _QTGMCRun.Mode.BOB, self, self.bob).run()
 
     def repair(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
@@ -1479,7 +1433,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Repaired clip.
         """
-        return self._run_process(clip, tff, self.repair)
+        return _QTGMCRun(clip, tff, _QTGMCRun.Mode.REPAIR, self, self.repair).run()
 
     def deshimmer(self, clip: vs.VideoNode) -> vs.VideoNode:
         """
@@ -1493,7 +1447,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Deshimmered clip.
         """
-        return self._run_process(clip, FieldBased.PROGRESSIVE, self.deshimmer)
+        return _QTGMCRun(clip, FieldBased.PROGRESSIVE, _QTGMCRun.Mode.DESHIMMER, self, self.deshimmer).run()
 
 
 def mask_shimmer(
@@ -1517,12 +1471,15 @@ def mask_shimmer(
     Args:
         flt: Filtered clip to perform masking on.
         src: Source clip to restore from.
-        erosion_distance: Vertical radius for shimmer detection. Larger values capture more spread-out shimmer artifacts
-            on soft sources. Defaults to 4.
+        erosion_distance: Vertical radius for shimmer detection. Larger values capture more spread-out artifacts on soft
+            sources. Defaults to 4.
         over_dilation: Extra dilation passes for safety margins. Larger values shrink the mask boundary to avoid
             artifacts on blurry edges. Defaults to 0.
         func: Function returned for custom error handling. This should only be set by VS package developers. Defaults to
             None.
+
+    Returns:
+        Clip with only bob shimmer fixes kept.
     """
     func = func or mask_shimmer
 
@@ -1544,8 +1501,8 @@ def mask_shimmer(
 
         if ed_res:
             clip = inflate_op(clip, func=func)
-            if ed_res == 2:
-                clip = median_blur(clip, func=func)
+        if ed_res == 2:
+            clip = median_blur(clip, func=func)
 
         clip = shrink_op(clip, iterations=ed_neg, coords=Coordinates.VERTICAL, func=func)
 

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -20,6 +20,7 @@ from vsdenoise import (
     refine_blksize,
 )
 from vsexprtools import norm_expr
+from vsjetpack import deprecated
 from vskernels import Bobber, BobberLike, Catrom
 from vsmasktools import Coordinates, Morpho
 from vsrgtools import BlurMatrix, gauss_blur, median_blur, remove_grain, repair, unsharpen
@@ -170,7 +171,7 @@ class _QTGMCBuilder:
 
         BOTH = auto()
         """
-        Back-blending both before and after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
+        Back-blending prior to and after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
 
         Provides a balanced middle ground between `PRELIMIT` and `POSTLIMIT` dampening.
 
@@ -233,6 +234,28 @@ class _QTGMCBuilder:
         def is_postsmooth(self) -> bool:
             return self in (self.SPATIAL_POSTSMOOTH, self.TEMPORAL_POSTSMOOTH)
 
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
+    class SearchPostProcess(CustomIntEnum):
+        GAUSSBLUR = 0
+        GAUSSBLUR_EDGESOFTEN = 1
+
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
+    class NoiseProcessMode(CustomIntEnum):
+        IDENTIFY = 0
+        DENOISE = 1
+
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
+    class SourceMatchMode(CustomIntEnum):
+        NONE = 0
+        BASIC = 1
+        REFINED = 2
+        TWICE_REFINED = 3
+
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
+    class SharpenMode(CustomIntEnum):
+        UNSHARP = 0
+        UNSHARP_MINMAX = 1
+
     def __init__(self, **kwargs: Any) -> None:
         """
         Args:
@@ -272,6 +295,7 @@ class _QTGMCBuilder:
         bias: float = 0.51,
         range_expansion_args: QTGMCArgs.PrefilterToFullRange | None = None,
         mask_shimmer_args: QTGMCArgs.MaskShimmer | None = None,
+        postprocess: SearchPostProcess | None = None,
     ) -> Self:
         """
         Configures parameters for the prefilter stage.
@@ -336,6 +360,9 @@ class _QTGMCBuilder:
         self.prefilter_bias = bias
         self.prefilter_range_expansion_args = fallback(range_expansion_args, QTGMCArgs.PrefilterToFullRange())
         self.prefilter_mask_shimmer_args = fallback(mask_shimmer_args, QTGMCArgs.MaskShimmer())
+
+        if postprocess is not None and not postprocess.value:  # TODO: remove
+            self.prefilter_limit = (0, 0, 0)
 
         return self
 
@@ -416,6 +443,7 @@ class _QTGMCBuilder:
         stabilize: float | Literal[False] = 0.4,
         func_comp_args: QTGMCArgs.Compensate | None = None,
         stabilize_comp_args: QTGMCArgs.Compensate | None = None,
+        mode: NoiseProcessMode | None = None,
     ) -> Self:
         """
         Configures parameters for the denoise stage.
@@ -468,6 +496,9 @@ class _QTGMCBuilder:
         self.denoise_stabilize = stabilize
         self.denoise_func_comp_args = fallback(func_comp_args, QTGMCArgs.Compensate())
         self.denoise_stabilize_comp_args = fallback(stabilize_comp_args, QTGMCArgs.Compensate())
+
+        if mode is not None:  # TODO: remove
+            self.denoise_full_denoise = bool(mode.value)
 
         return self
 
@@ -564,6 +595,7 @@ class _QTGMCBuilder:
         similarity: float = 0.5,
         enhance: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
+        mode: SourceMatchMode = SourceMatchMode.NONE,
     ) -> Self:
         """
         Configures parameters for source match processing.
@@ -608,6 +640,9 @@ class _QTGMCBuilder:
         self.source_match_similarity = similarity
         self.source_match_enhance = enhance
         self.source_match_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
+
+        if mode is not None:  # TODO: remove
+            self.source_match_iterations = mode.value  # type: ignore
 
         return self
 
@@ -658,6 +693,7 @@ class _QTGMCBuilder:
         strength: float | None = None,
         offset: float | tuple[float, float] | Literal[False] = 1,
         thin: float = 0,
+        mode: SharpenMode | None = None,
     ) -> Self:
         """
         Configures parameters for sharpening.
@@ -683,6 +719,9 @@ class _QTGMCBuilder:
         self.sharpen_strength = strength
         self.sharpen_offset = offset is not False and normalize_seq(offset, 2)
         self.sharpen_thin = thin
+
+        if mode is not None and not mode.value:  # TODO: remove
+            self.sharpen_offset = False
 
         return self
 
@@ -1096,7 +1135,7 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def repair_mask_enabled(self) -> bool:
-        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml", 0))
+        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml"))
 
     @cachedproperty
     def motion_blur_level(self) -> float:
@@ -1356,7 +1395,7 @@ class _QTGMCGraph(VSObject):
                 **self.settings.motion_blur_blur_args,
             )
 
-            if self.settings.motion_blur_mask_args.get("ml", 0):
+            if self.settings.motion_blur_mask_args.get("ml"):
                 mask = self.mv.mask(
                     direction=MVDirection.BACKWARD,
                     kind=MaskMode.VECTOR_LENGTH,

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1218,7 +1218,7 @@ class QTGMCGraph(VSObject):
         Used as a base for [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter] and
         [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
 
-        Only available after processing a clip that requires motion-compensated processing or denoising.
+        Only available when using denoising or motion-compensated processing.
         """
 
         if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
@@ -1231,7 +1231,7 @@ class QTGMCGraph(VSObject):
         """
         Output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter].
 
-        Only available after processing a clip that requires internally generated motion vectors.
+        Only available when motion vectors need to be generated.
         """
 
         if self.mode is self.Mode.REPAIR:
@@ -1274,7 +1274,7 @@ class QTGMCGraph(VSObject):
         """
         [MVTools][vsdenoise.mvtools.mvtools.MVTools] instance used during processing.
 
-        Only available after processing a clip that requires motion analysis.
+        Only available when using motion-compensated processing.
         """
 
         preset = dict(self.settings.analyze_preset)
@@ -1341,7 +1341,7 @@ class QTGMCGraph(VSObject):
         """
         Noise extracted by [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
 
-        Only available after processing a clip that requires noise restoration.
+        Only available when using noise restoration.
         """
 
         noise = self.clip.std.MakeDiff(self._run_denoiser)

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -53,7 +53,7 @@ class QTGMCArgs:
     """Namespace containing helper TypedDict definitions for various argument groups."""
 
     class MaskShimmer(TypedDict, total=False):
-        """Arguments accepted by [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]."""
+        """Arguments accepted by [mask_shimmer][vsdeinterlace.mask_shimmer]."""
 
         erosion_distance: int
         over_dilation: int
@@ -71,7 +71,7 @@ class QTGMCArgs:
         time: float | None
 
     class Degrain(TypedDict, total=False):
-        """Arguments accepted by the internal `binomial_degrain` method."""
+        """Arguments accepted by the internal `_binomial_degrain` method."""
 
         limit: float | tuple[float, float] | None
         planes: Planes
@@ -92,6 +92,8 @@ class QTGMCArgs:
 
 class _QTGMCBuilder:
     class NoiseDeintMode(CustomIntEnum):
+        """How to 'deinterlace' noise taken from an interlaced source before restoration."""
+
         WEAVE = auto()
         """
         Double weave source noise.
@@ -112,6 +114,8 @@ class _QTGMCBuilder:
         """
 
     class LosslessMode(CustomIntEnum):
+        """When to put the original fields into the output."""
+
         NONE = auto()
         """
         Do not restore the original fields.
@@ -133,6 +137,8 @@ class _QTGMCBuilder:
         """
 
     class BackBlendMode(CustomIntEnum):
+        """When to back-blend the (blurred) difference between the pre- and post-sharpened clips."""
+
         NONE = auto()
         """
         No back-blending.
@@ -170,6 +176,8 @@ class _QTGMCBuilder:
         """
 
     class SharpenLimitMode(CustomIntEnum):
+        """How and when to apply limiting to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen]."""
+
         NONE = auto()
         """
         No sharpness limiting.
@@ -249,7 +257,7 @@ class _QTGMCBuilder:
         """
         Args:
             **kwargs: Additional arguments to be passed to the parameter category methods. Separate the method name
-                from its argument with two underscores, for example: `sharpen_limit__mode`.
+                from its argument with two underscores, for example: `sharpen_limit__radius=1`.
         """
 
         settings_methods = (
@@ -282,8 +290,8 @@ class _QTGMCBuilder:
         strength: tuple[float, float] = (1.9, 0.9),
         limit: tuple[float, float, float] = (3, 7, 2),
         bias: float = 0.51,
-        range_expansion_args: QTGMCArgs.PrefilterToFullRange | None = None,
         mask_shimmer_args: QTGMCArgs.MaskShimmer | None = None,
+        range_expansion_args: QTGMCArgs.PrefilterToFullRange | None = None,
         postprocess: SearchPostProcess | None = None,
     ) -> Self:
         """
@@ -336,10 +344,10 @@ class _QTGMCBuilder:
                 Defaults to (3, 7, 2).
             bias: Weight used when blending the Gaussian-blurred clip back with the limited clip. Higher
                 values give more weight to the Gaussian-blurred clip. Defaults to 0.51.
+            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.mask_shimmer]. Defaults
+                to None.
             range_expansion_args: Additional arguments passed to
                 [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range]. Defaults to None.
-            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
-                to None.
         """
 
         self.prefilter_tr = tr
@@ -347,8 +355,8 @@ class _QTGMCBuilder:
         self.prefilter_strength = strength
         self.prefilter_limit = limit
         self.prefilter_bias = bias
-        self.prefilter_range_expansion_args = fallback(range_expansion_args, QTGMCArgs.PrefilterToFullRange())
         self.prefilter_mask_shimmer_args = fallback(mask_shimmer_args, QTGMCArgs.MaskShimmer())
+        self.prefilter_range_expansion_args = fallback(range_expansion_args, QTGMCArgs.PrefilterToFullRange())
 
         if postprocess is not None and not postprocess.value:  # TODO: remove
             self.prefilter_limit = (0, 0, 0)
@@ -424,11 +432,11 @@ class _QTGMCBuilder:
     def denoise(
         self,
         *,
-        tr: int = 1,
         func: DFTTest | _DenoiseFuncTr = _DFTTEST_DEFAULT,
+        tr: int = 1,
         deint: NoiseDeintMode = NoiseDeintMode.GENERATE,
-        full_denoise: bool = False,
         mc_denoise: bool = True,
+        full_denoise: bool = False,
         stabilize: float | Literal[False] = 0.4,
         func_comp_args: QTGMCArgs.Compensate | None = None,
         stabilize_comp_args: QTGMCArgs.Compensate | None = None,
@@ -459,15 +467,15 @@ class _QTGMCBuilder:
                 variance and the extracted noise.
 
         Args:
+            func: Denoising function to use. Defaults to DFTTest(sigma=8).
             tr: Temporal radius of the denoising function and its motion compensation. Larger values remove/separate
                 more noise. Defaults to 1.
-            func: Denoising function to use. Defaults to DFTTest(sigma=8).
-            deint: Specifies how to 'deinterlace' noise taken from an interlaced source before restoration. Defaults to
+            deint: How to 'deinterlace' noise taken from an interlaced source before restoration. Defaults to
                 NoiseDeintMode.GENERATE.
-            full_denoise: Whether the denoised output will be directly used in all subsequent processing. If `False`,
-                the denoising is only for noise extraction. Defaults to False.
             mc_denoise: Whether to motion-compensate the denoiser being used. Provides more accurate denoising/noise
                 extraction when using a non-motion-compensated temporal denoiser. Defaults to True.
+            full_denoise: Whether the denoised output will be directly used in all subsequent processing. If `False`,
+                the denoising is only for noise extraction. Defaults to False.
             stabilize: Weight used when blending max noise variance with averaged noise. Higher values give more
                 weight to the averaged noise. `False` disables stabilization. Defaults to 0.4.
             func_comp_args: Additional arguments passed to
@@ -477,11 +485,11 @@ class _QTGMCBuilder:
                 None.
         """
 
-        self.denoise_tr = tr
         self.denoise_func = func.denoise if isinstance(func, DFTTest) else func
+        self.denoise_tr = tr
         self.denoise_deint = deint
-        self.denoise_full_denoise = full_denoise
         self.denoise_mc_denoise = mc_denoise
+        self.denoise_full_denoise = full_denoise
         self.denoise_stabilize = stabilize
         self.denoise_func_comp_args = fallback(func_comp_args, QTGMCArgs.Compensate())
         self.denoise_stabilize_comp_args = fallback(stabilize_comp_args, QTGMCArgs.Compensate())
@@ -510,13 +518,13 @@ class _QTGMCBuilder:
     def basic(
         self,
         *,
+        bobber: BobberLike = _NNEDI3_DEFAULT,
         tr: int = 2,
         thsad: int | tuple[int, int] = 640,
         thsad2: int | tuple[int, int] | None = None,
-        bobber: BobberLike = _NNEDI3_DEFAULT,
         noise_restore: float = 0,
-        degrain_args: QTGMCArgs.Degrain | None = None,
         mask_args: QTGMCArgs.Mask | None = None,
+        degrain_args: QTGMCArgs.Degrain | None = None,
         mask_shimmer_args: QTGMCArgs.MaskShimmer | None = None,
     ) -> Self:
         """
@@ -545,6 +553,7 @@ class _QTGMCBuilder:
                 [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of this stage.
 
         Args:
+            bobber: Bobber to use for spatial interpolation. Defaults to NNEDI3(nsize=1).
             tr: Temporal radius of the motion-compensated binomial blur. Larger values reduce more shimmer but can
                 introduce blurring and ghosting. Defaults to 2.
             thsad: SAD threshold of the motion-compensated binomial blur. Larger values reduce more shimmer but can
@@ -553,24 +562,23 @@ class _QTGMCBuilder:
             thsad2: Second SAD threshold of the motion-compensated linear blur. Larger values clean more artifacts but
                 can introduce blurring and ghosting. Passing a tuple of values results in per-plane thresholds. Defaults
                 to None.
-            bobber: Bobber to use for spatial interpolation. Defaults to NNEDI3(nsize=1).
             noise_restore: Amount of noise to restore after this stage. Used to retain stable noise. Defaults to 0.
-            degrain_args: Additional arguments passed to the internal `binomial_degrain` call. Defaults to None.
             mask_args: Additional arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]. Only used
                 for [QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]. Defaults to {"ml": 10}.
-            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
+            degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
+            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.mask_shimmer]. Defaults
                 to {"erosion_distance": 0}.
         """
 
-        self.basic_tr = tr
-        self.basic_thsad = thsad
-        self.basic_thsad2 = thsad2
         self.basic_bobber = (
             deepcopy(bobber) if isinstance(bobber, Bobber) else Bobber.ensure_obj(bobber, self.__class__)
         )
+        self.basic_tr = tr
+        self.basic_thsad = thsad
+        self.basic_thsad2 = thsad2
         self.basic_noise_restore = noise_restore
-        self.basic_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
         self.basic_mask_args = QTGMCArgs.Mask(ml=10) | (mask_args or {})
+        self.basic_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
         self.basic_mask_shimmer_args = QTGMCArgs.MaskShimmer(erosion_distance=0) | (mask_shimmer_args or {})
 
         return self
@@ -578,9 +586,9 @@ class _QTGMCBuilder:
     def source_match(
         self,
         *,
-        tr: int = 1,
-        bobber: BobberLike | None = None,
         iterations: Literal[0, 1, 2, 3] = 0,
+        bobber: BobberLike | None = None,
+        tr: int = 1,
         similarity: float = 0.5,
         enhance: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
@@ -609,23 +617,23 @@ class _QTGMCBuilder:
                     reduces the accuracy of source matching.
 
         Args:
-            tr: Temporal radius of the refinement motion-compensated binomial blur. Larger values reduce more shimmer
-                but can introduce blurring and ghosting. Only used for `iterations` > 1. Defaults to 1.
-            bobber: Bobber to use for refined spatial interpolation. Only used for `iterations` > 1. Defaults to
-                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `bobber`.
             iterations: Number of source match iterations to perform. Higher values are slower and more accurate. Using
                 2 or 3 iterations restores almost exact source detail but is sensitive to noise and introduces
                 occasional aliasing (to a lesser extent for 3). Requires
                 [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `tr` > 0 Defaults to 0.
+            bobber: Bobber to use for refined spatial interpolation. Only used for `iterations` > 1. Defaults to
+                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `bobber`.
+            tr: Temporal radius of the refinement motion-compensated binomial blur. Larger values reduce more shimmer
+                but can introduce blurring and ghosting. Only used for `iterations` > 1. Defaults to 1.
             similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
                 Defaults to 0.5.
             enhance: Enhances detail found by `iterations` > 1. Higher values exaggerate detail more. Defaults to 0.5.
-            degrain_args: Additional arguments passed to the internal `binomial_degrain` call. Defaults to None.
+            degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
         """
 
-        self.source_match_tr = tr
-        self.source_match_bobber = bobber
         self.source_match_iterations = iterations
+        self.source_match_bobber = bobber
+        self.source_match_tr = tr
         self.source_match_similarity = similarity
         self.source_match_enhance = enhance
         self.source_match_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
@@ -851,7 +859,7 @@ class _QTGMCBuilder:
             noise_restore: Amount of noise to restore after this stage. Used to retain any noise. Defaults to 0.
             degrain_args: Additional arguments passed to [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain].
                 Defaults to None.
-            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]. Defaults
+            mask_shimmer_args: Additional arguments passed to [mask_shimmer][vsdeinterlace.mask_shimmer]. Defaults
                 to None.
         """
 
@@ -905,18 +913,55 @@ class _QTGMCBuilder:
         return self
 
 
-class _QTGMCGraph(VSObject):
+class QTGMCGraph(VSObject):
+    """
+    Processing graph for a single [QTempGaussMC][vsdeinterlace.QTempGaussMC] operation.
+
+    The graph exposes each processing stage as a lazily evaluated cached property. It is returned alongside the output
+    clip when `return_graph=True` is passed to a [QTempGaussMC][vsdeinterlace.QTempGaussMC] processing method. This
+    allows the intermediate clips and motion vectors used to produce the output to be inspected or reused.
+
+    Returned graphs are frozen after evaluation so that access is limited to stages used to construct the output.
+    """
+
     class Mode(CustomIntEnum):
+        """Processing mode used to construct the graph."""
+
         DEINTERLACE = auto()
+        """
+        Deinterlace interlaced input.
+
+        Interpolates missing fields to reconstruct progressive frames.
+        [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is respected.
+        """
+
         BOB = auto()
+        """
+        Bob interlaced input.
+
+        Interpolates missing fields to reconstruct progressive frames.
+        [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is ignored.
+        """
+
         REPAIR = auto()
+        """
+        Repair badly deinterlaced input.
+
+        Drops half the fields to recreate an interlaced clip using the remaining ones.
+        """
+
         DESHIMMER = auto()
+        """
+        Deshimmer progressive input.
+
+        Removes horizontal shimmering artifacts from progressive sources.
+        """
 
     class _FrozenCache(dict[str, Any]):
         def __contains__(self, key: object) -> bool:
-            return True
+            if super().__contains__(key):
+                return True
 
-        def __missing__(self, key: str) -> Any:
             raise AttributeError(key)
 
     def __init__(
@@ -927,6 +972,18 @@ class _QTGMCGraph(VSObject):
         settings: _QTGMCBuilder,
         func: FuncExcept,
     ) -> None:
+        """
+        Args:
+            clip: Clip to process.
+            tff: Field order (top-field-first). If `None`, inferred from the clip.
+            mode: Processing mode used to construct the graph.
+            settings: `_QTGMCBuilder` instance containing the settings for each processing stage.
+            func: Function returned for custom error handling. This should only be set by VS package developers.
+
+        Raises:
+            UnsupportedFieldBasedError: If `clip` is progressive and `mode` is not `Mode.DESHIMMER`.
+        """
+
         self.clip = clip
         self.tff = FieldBased.from_param_or_video(tff, clip, True, func)
         self.mode = mode
@@ -937,6 +994,13 @@ class _QTGMCGraph(VSObject):
             raise UnsupportedFieldBasedError("This mode is incompatible with progressive video!", func)
 
     def freeze(self) -> Self:
+        """
+        Freeze the graph at its current evaluation state.
+
+        Cached properties remain accessible; however, attempting to access a property that has not been evaluated raises
+        an `AttributeError`
+        """
+
         cache = self.__dict__.setdefault(cachedproperty.cache_key, {})
 
         if not isinstance(cache, self._FrozenCache):
@@ -944,13 +1008,13 @@ class _QTGMCGraph(VSObject):
 
         return self
 
-    def interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
+    def _interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
         if self.mode is not self.Mode.DESHIMMER:
             clip = bobber.bob(clip, tff=self.tff)
 
         return clip
 
-    def binomial_degrain(self, clip: vs.VideoNode, tr: int, **degrain_args: Any) -> vs.VideoNode:
+    def _binomial_degrain(self, clip: vs.VideoNode, tr: int, **degrain_args: Any) -> vs.VideoNode:
         if not tr:
             return clip
 
@@ -964,7 +1028,7 @@ class _QTGMCGraph(VSObject):
             **degrain_args,
         )
 
-    def source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
+    def _source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
         def error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
             if not tr:
                 return ref
@@ -977,32 +1041,32 @@ class _QTGMCGraph(VSObject):
             return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=error_adjustment)
 
         if self.mode is not self.Mode.DESHIMMER:
-            clip = reinterlace(clip, self.tff, self.source_match)
+            clip = reinterlace(clip, self.tff, self._source_match)
 
         adjusted = error_adjustment(self.bob_input, clip, self.settings.basic_tr)
-        new_bobbed = self.interpolate(adjusted, self.settings.basic_bobber)
-        matched = self.binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
+        new_bobbed = self._interpolate(adjusted, self.settings.basic_bobber)
+        matched = self._binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
 
         if self.settings.source_match_iterations > 1:
             if self.settings.source_match_enhance:
                 matched = unsharpen(
-                    matched, self.settings.source_match_enhance, BlurMatrix.BINOMIAL(), func=self.source_match
+                    matched, self.settings.source_match_enhance, BlurMatrix.BINOMIAL(), func=self._source_match
                 )
 
             if self.mode is not self.Mode.DESHIMMER:
-                clip = reinterlace(matched, self.tff, self.source_match)
+                clip = reinterlace(matched, self.tff, self._source_match)
             else:
                 clip = matched
 
             diff = self.bob_input.std.MakeDiff(clip)
-            refine_bobbed = self.interpolate(diff, self.settings.source_match_bobber)
-            refine_matched = self.binomial_degrain(
+            refine_bobbed = self._interpolate(diff, self.settings.source_match_bobber)
+            refine_matched = self._binomial_degrain(
                 refine_bobbed, self.settings.source_match_tr, **self.settings.source_match_degrain_args
             )
 
             if self.settings.source_match_iterations > 2:
                 refine_adjusted = error_adjustment(refine_bobbed, refine_matched, self.settings.source_match_tr)
-                refine_matched = self.binomial_degrain(
+                refine_matched = self._binomial_degrain(
                     refine_adjusted, self.settings.source_match_tr, **self.settings.source_match_degrain_args
                 )
 
@@ -1010,7 +1074,7 @@ class _QTGMCGraph(VSObject):
 
         return matched
 
-    def lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
+    def _lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
         if self.mode is self.Mode.DESHIMMER or clip is self.bobbed:
             return clip
 
@@ -1019,68 +1083,68 @@ class _QTGMCGraph(VSObject):
             fields_src = fields_src.std.SelectEvery(4, (0, 3))
         fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
 
-        woven = reweave(fields_src, fields_flt, self.tff.field, self.lossless)
+        woven = reweave(fields_src, fields_flt, self.tff.field, self._lossless)
 
         if self.settings.lossless_anti_comb:
-            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self.lossless).std.MakeDiff(woven)
+            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self._lossless).std.MakeDiff(woven)
             fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
 
             cleaned_diff = norm_expr(
-                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self.lossless), fields_diff],
+                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self._lossless), fields_diff],
                 "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
-                func=self.lossless,
+                func=self._lossless,
             )
             cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
-            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self.lossless)
+            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self._lossless)
 
         return FieldBased.PROGRESSIVE.apply(woven)
 
-    def sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
+    def _sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
         resharp = clip
 
         if self.settings.sharpen_strength:
             if self.settings.sharpen_offset is not False:
                 dark_offset, bright_offset = self.settings.sharpen_offset
 
-                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self.sharpen)
-                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self.sharpen)
+                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self._sharpen)
+                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self._sharpen)
 
                 resharp = norm_expr(
                     [clip, source_min, source_max],
                     "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
                     dark_offset=scale_delta(dark_offset, 8, self.clip),
                     bright_offset=scale_delta(bright_offset, 8, self.clip),
-                    func=self.sharpen,
+                    func=self._sharpen,
                 )
 
             resharp = unsharpen(
                 clip,
                 self.settings.sharpen_strength,
-                BlurMatrix.BINOMIAL()(resharp, func=self.sharpen),
-                func=self.sharpen,
+                BlurMatrix.BINOMIAL()(resharp, func=self._sharpen),
+                func=self._sharpen,
             )
 
         if self.settings.sharpen_thin:
             median_diff = norm_expr(
-                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self.sharpen)],
+                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self._sharpen)],
                 "y x - {thin} * neutral +",
                 thin=self.settings.sharpen_thin,
-                func=self.sharpen,
+                func=self._sharpen,
             )
-            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self.sharpen)
+            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self._sharpen)
 
             resharp = norm_expr(
-                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self.sharpen), blurred_diff],
+                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self._sharpen), blurred_diff],
                 "y neutral - dup abs z neutral - abs > swap x + x ?",
-                func=self.sharpen,
+                func=self._sharpen,
             )
 
         return resharp
 
-    def back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
+    def _back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
         return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_sigma))
 
-    def sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
+    def _sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
         undershoot, overshoot = self.settings.sharpen_limit_clamp
 
         if self.settings.sharpen_limit_mode.is_spatial:
@@ -1088,17 +1152,17 @@ class _QTGMCGraph(VSObject):
                 clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
             else:
                 inpand = Morpho.minimum(
-                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self.sharpen_limit
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self._sharpen_limit
                 )
                 expand = Morpho.maximum(
-                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self.sharpen_limit
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self._sharpen_limit
                 )
                 clip = norm_expr(
                     [clip, inpand, expand],
                     "x y {undershoot} - z {overshoot} + clamp",
                     undershoot=scale_delta(undershoot, 8, self.clip),
                     overshoot=scale_delta(overshoot, 8, self.clip),
-                    func=self.sharpen_limit,
+                    func=self._sharpen_limit,
                 )
         elif self.settings.sharpen_limit_mode.is_temporal:
             clip = mc_clamp(
@@ -1106,7 +1170,7 @@ class _QTGMCGraph(VSObject):
                 self.bobbed,
                 self.mv,
                 (undershoot, overshoot),
-                self.sharpen_limit,
+                self._sharpen_limit,
                 tr=self.settings.sharpen_limit_radius,
                 thscd=self.settings.analyze_thscd,
                 **self.settings.sharpen_limit_comp_args,
@@ -1114,30 +1178,39 @@ class _QTGMCGraph(VSObject):
 
         return clip
 
-    def noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
+    def _noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
         if restore:
             clip = norm_expr(
-                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self.noise_restore
+                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self._noise_restore
             )
 
         return clip
 
     @cachedproperty
-    def repair_mask_enabled(self) -> bool:
+    def _repair_mask_enabled(self) -> bool:
         return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml") != 0)
 
     @cachedproperty
-    def motion_blur_level(self) -> float:
+    def _motion_blur_level(self) -> float:
         angle_in, angle_out = self.settings.motion_blur_shutter_angle
 
-        return (angle_out * self.motion_blur_fps_divisor - angle_in) * 100 / 360
+        return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
 
     @cachedproperty
-    def motion_blur_fps_divisor(self) -> int:
+    def _motion_blur_fps_divisor(self) -> int:
         return 1 if self.mode is self.Mode.BOB else self.settings.motion_blur_fps_divisor
 
     @cachedproperty
     def draft(self) -> vs.VideoNode:
+        """
+        Draft processed clip.
+
+        Used as a base for [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter] and
+        [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
+
+        Only available after processing a clip that requires motion-compensated processing or denoising.
+        """
+
         if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
             return Catrom().bob(self.clip, tff=self.tff)
 
@@ -1145,6 +1218,12 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def prefilter(self) -> vs.VideoNode:
+        """
+        Output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter].
+
+        Only available after processing a clip that requires internally generated motion vectors.
+        """
+
         if self.mode is self.Mode.REPAIR:
             search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self.func)
         else:
@@ -1182,6 +1261,12 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def mv(self) -> MVTools:
+        """
+        [MVTools][vsdenoise.mvtools.mvtools.MVTools] instance used during processing.
+
+        Only available after processing a clip that requires motion analysis.
+        """
+
         preset = dict(self.settings.analyze_preset)
         if not self.settings.analyze_vectors:
             preset.update(search_clip=self.prefilter)
@@ -1196,7 +1281,7 @@ class _QTGMCGraph(VSObject):
             self.settings._mc_denoise_tr,
             self.settings._stabilization_enabled,
             self.settings.basic_tr,
-            self.repair_mask_enabled,
+            self._repair_mask_enabled,
             self.settings.source_match_tr
             if self.settings.source_match_iterations > 1 and self.settings._source_match_enabled
             else 0,
@@ -1204,7 +1289,7 @@ class _QTGMCGraph(VSObject):
             if self.settings.sharpen_limit_mode.is_temporal and self.settings._sharpness_limiting_enabled
             else 0,
             self.settings.final_tr,
-            bool(self.motion_blur_level),
+            bool(self._motion_blur_level),
         )
 
         mv.analyze(tr=tr, blksize=self.settings.analyze_blksize, overlap_div=self.settings.analyze_overlap)
@@ -1219,7 +1304,7 @@ class _QTGMCGraph(VSObject):
         return mv
 
     @cachedproperty
-    def run_denoiser(self) -> vs.VideoNode:
+    def _run_denoiser(self) -> vs.VideoNode:
         if self.settings._mc_denoise_tr:
             denoised = self.mv.compensate(
                 tr=self.settings.denoise_tr,
@@ -1237,11 +1322,19 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def denoise(self) -> vs.VideoNode:
-        return self.run_denoiser if self.settings.denoise_full_denoise else self.clip
+        """Output of [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
+
+        return self._run_denoiser if self.settings.denoise_full_denoise else self.clip
 
     @cachedproperty
     def noise(self) -> vs.VideoNode:
-        noise = self.clip.std.MakeDiff(self.run_denoiser)
+        """
+        Noise extracted by [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
+
+        Only available after processing a clip that requires noise restoration.
+        """
+
+        noise = self.clip.std.MakeDiff(self._run_denoiser)
 
         if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
             match self.settings.denoise_deint:
@@ -1292,6 +1385,13 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def bob_input(self) -> vs.VideoNode:
+        """
+        Prepared input clip for high-quality interpolation.
+
+        Used as a base for the internal `_interpolate` method and as a reference for
+        [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
+        """
+
         if self.mode is self.Mode.REPAIR:
             return reinterlace(self.denoise, self.tff, self.func)
 
@@ -1299,9 +1399,16 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def bobbed(self) -> vs.VideoNode:
-        bobbed = self.interpolate(self.bob_input, self.settings.basic_bobber)
+        """
+        High-quality bobbed clip.
 
-        if self.repair_mask_enabled:
+        Used as a spatial interpolation base for [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
+        [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
+        """
+
+        bobbed = self._interpolate(self.bob_input, self.settings.basic_bobber)
+
+        if self._repair_mask_enabled:
             mask = self.mv.mask(
                 direction=MVDirection.BACKWARD,
                 kind=MaskMode.SAD,
@@ -1314,43 +1421,47 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def basic(self) -> vs.VideoNode:
-        smoothed = self.binomial_degrain(self.bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
+        """Output of [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]."""
+
+        smoothed = self._binomial_degrain(self.bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
 
         if self.settings.basic_tr:
             smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.func)
 
         if self.settings._source_match_enabled:
-            smoothed = self.source_match(smoothed)
+            smoothed = self._source_match(smoothed)
 
         if self.settings.lossless_mode is self.settings.LosslessMode.PRESHARPEN:
-            smoothed = self.lossless(smoothed)
+            smoothed = self._lossless(smoothed)
 
         if self.settings._sharpening_enabled:
-            resharp = self.sharpen(smoothed)
+            resharp = self._sharpen(smoothed)
 
             if self.settings.sharpen_limit_mode.is_presmooth and self.settings._sharpness_limiting_enabled:
                 if self.settings.back_blend_mode in (
                     self.settings.BackBlendMode.PRELIMIT,
                     self.settings.BackBlendMode.BOTH,
                 ):
-                    resharp = self.back_blend(resharp, smoothed)
+                    resharp = self._back_blend(resharp, smoothed)
 
-                resharp = self.sharpen_limit(resharp)
+                resharp = self._sharpen_limit(resharp)
 
                 if self.settings.back_blend_mode in (
                     self.settings.BackBlendMode.POSTLIMIT,
                     self.settings.BackBlendMode.BOTH,
                 ):
-                    resharp = self.back_blend(resharp, smoothed)
+                    resharp = self._back_blend(resharp, smoothed)
             elif self.settings.back_blend_mode is not self.settings.BackBlendMode.NONE:
-                resharp = self.back_blend(resharp, smoothed)
+                resharp = self._back_blend(resharp, smoothed)
         else:
             resharp = smoothed
 
-        return self.noise_restore(resharp, self.settings.basic_noise_restore)
+        return self._noise_restore(resharp, self.settings.basic_noise_restore)
 
     @cachedproperty
     def final(self) -> vs.VideoNode:
+        """Output of [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final]."""
+
         if self.settings.final_tr:
             smoothed = self.mv.degrain(
                 self.basic,
@@ -1367,19 +1478,21 @@ class _QTGMCGraph(VSObject):
             smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.final_mask_shimmer_args, func=self.func)
 
         if self.settings.sharpen_limit_mode.is_postsmooth and self.settings._sharpness_limiting_enabled:
-            smoothed = self.sharpen_limit(smoothed)
+            smoothed = self._sharpen_limit(smoothed)
 
         if self.settings.lossless_mode is self.settings.LosslessMode.POSTSMOOTH:
-            smoothed = self.lossless(smoothed)
+            smoothed = self._lossless(smoothed)
 
-        return self.noise_restore(smoothed, self.settings.final_noise_restore)
+        return self._noise_restore(smoothed, self.settings.final_noise_restore)
 
     @cachedproperty
     def motion_blur(self) -> vs.VideoNode:
-        if self.motion_blur_level:
+        """Output of [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur]."""
+
+        if self._motion_blur_level:
             blurred = self.mv.flow_blur(
                 self.final,
-                blur=self.motion_blur_level,
+                blur=self._motion_blur_level,
                 thscd=self.settings.analyze_thscd,
                 **self.settings.motion_blur_blur_args,
             )
@@ -1396,8 +1509,8 @@ class _QTGMCGraph(VSObject):
         else:
             blurred = self.final
 
-        if self.motion_blur_fps_divisor > 1:
-            blurred = blurred[:: self.motion_blur_fps_divisor]
+        if self._motion_blur_fps_divisor > 1:
+            blurred = blurred[:: self._motion_blur_fps_divisor]
 
         return blurred
 
@@ -1412,32 +1525,37 @@ class QTempGaussMC(_QTGMCBuilder):
 
     Originally based on TempGaussMC by Didée.
 
-    Usage Info: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Basic Usage:
+        ```python
+        deinterlace = QTempGaussMC().deinterlace(clip)
+        ```
+
+    Additional Usage Info: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     @overload
     def deinterlace(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: Literal[False] = False
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: Literal[False] = False
     ) -> vs.VideoNode: ...
 
     @overload
     def deinterlace(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, debug: Literal[True]
-    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, return_graph: Literal[True]
+    ) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
     def deinterlace(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, debug: Literal[True]
-    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, return_graph: Literal[True]
+    ) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
     def deinterlace(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = ...
-    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]: ...
 
     def deinterlace(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
-    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]:
         """
         Deinterlace interlaced input.
 
@@ -1447,43 +1565,45 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
-            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
+            return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
+                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                motion-compensated processing. Defaults to False.
 
         Returns:
-            The deinterlaced clip, or a tuple of (clip, graph) containing the deinterlaced clip and the internal
-            `_QTGMCGraph` object if debug is `True`
+            The deinterlaced clip, or a tuple of (clip, graph) containing the deinterlaced clip and its `QTGMCGraph`
+            object if `return_graph` is `True`.
         """
 
-        run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace)
+        run = QTGMCGraph(clip, tff, QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace)
 
-        if debug:
+        if return_graph:
             return run.motion_blur, run.freeze()
 
         return run.motion_blur
 
     @overload
     def bob(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: Literal[False] = False
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: Literal[False] = False
     ) -> vs.VideoNode: ...
 
     @overload
     def bob(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, debug: Literal[True]
-    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, return_graph: Literal[True]
+    ) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
     def bob(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, debug: Literal[True]
-    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, return_graph: Literal[True]
+    ) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
     def bob(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = ...
-    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]: ...
 
     def bob(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
-    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]:
         """
         Bob interlaced input.
 
@@ -1493,43 +1613,45 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
-            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
+            return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
+                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                motion-compensated processing. Defaults to False.
 
         Returns:
-            The bobbed clip, or a tuple of (clip, graph) containing the bobbed clip and the internal `_QTGMCGraph`
-            object if debug is `True`
+            The bobbed clip, or a tuple of (clip, graph) containing the bobbed clip and its `QTGMCGraph` object if
+            `return_graph` is `True`.
         """
 
-        run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.BOB, self, self.bob)
+        run = QTGMCGraph(clip, tff, QTGMCGraph.Mode.BOB, self, self.bob)
 
-        if debug:
+        if return_graph:
             return run.motion_blur, run.freeze()
 
         return run.motion_blur
 
     @overload
     def repair(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: Literal[False] = False
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: Literal[False] = False
     ) -> vs.VideoNode: ...
 
     @overload
     def repair(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, debug: Literal[True]
-    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, return_graph: Literal[True]
+    ) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
     def repair(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, debug: Literal[True]
-    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, return_graph: Literal[True]
+    ) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
     def repair(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = ...
-    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]: ...
 
     def repair(
-        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
-    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, return_graph: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]:
         """
         Repair badly deinterlaced input.
 
@@ -1538,30 +1660,36 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
-            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
+            return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
+                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                motion-compensated processing. Defaults to False.
 
         Returns:
-            The repaired clip, or a tuple of (clip, graph) containing the repaired clip and the internal `_QTGMCGraph`
-            object if debug is `True`
+            The repaired clip, or a tuple of (clip, graph) containing the repaired clip and its `QTGMCGraph` object if
+            `return_graph` is `True`.
         """
 
-        run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.REPAIR, self, self.repair)
+        run = QTGMCGraph(clip, tff, QTGMCGraph.Mode.REPAIR, self, self.repair)
 
-        if debug:
+        if return_graph:
             return run.motion_blur, run.freeze()
 
         return run.motion_blur
 
     @overload
-    def deshimmer(self, clip: vs.VideoNode, debug: Literal[False] = False) -> vs.VideoNode: ...
+    def deshimmer(self, clip: vs.VideoNode, return_graph: Literal[False] = False) -> vs.VideoNode: ...
 
     @overload
-    def deshimmer(self, clip: vs.VideoNode, debug: Literal[True]) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+    def deshimmer(self, clip: vs.VideoNode, return_graph: Literal[True]) -> tuple[vs.VideoNode, QTGMCGraph]: ...
 
     @overload
-    def deshimmer(self, clip: vs.VideoNode, debug: bool = ...) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+    def deshimmer(
+        self, clip: vs.VideoNode, return_graph: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]: ...
 
-    def deshimmer(self, clip: vs.VideoNode, debug: bool = False) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
+    def deshimmer(
+        self, clip: vs.VideoNode, return_graph: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, QTGMCGraph]:
         """
         Deshimmer progressive input.
 
@@ -1569,16 +1697,18 @@ class QTempGaussMC(_QTGMCBuilder):
 
         Args:
             clip: Clip to process.
-            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
+            return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
+                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                motion-compensated processing. Defaults to False.
 
         Returns:
-            The deshimmered clip, or a tuple of (clip, graph) containing the deshimmered clip and the internal
-            `_QTGMCGraph` object if debug is `True`
+            The deshimmered clip, or a tuple of (clip, graph) containing the deshimmered clip and its `QTGMCGraph`
+                object if `return_graph` is `True`.
         """
 
-        run = _QTGMCGraph(clip, FieldBased.PROGRESSIVE, _QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer)
+        run = QTGMCGraph(clip, FieldBased.PROGRESSIVE, QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer)
 
-        if debug:
+        if return_graph:
             return run.motion_blur, run.freeze()
 
         return run.motion_blur

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -959,7 +959,7 @@ class QTGMCGraph(VSObject):
         prefilter = graph.prefilter
         ```
 
-    Additional Usage Info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Additional usage info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     class Mode(CustomIntEnum):
@@ -1590,7 +1590,7 @@ class QTempGaussMC(_QTGMCBuilder):
         deinterlaced = QTempGaussMC().lossless(QTempGaussMC.LosslessMode.PRESHARPEN).final(tr=2).deinterlace(clip)
         ```
 
-    Additional Usage Info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Additional usage info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     @overload

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -906,6 +906,7 @@ class _QTGMCBuilder:
 
     @property
     def _sharpen_sigma(self) -> float:
+        # Combined variance of the (binomial) basic blur and (linear) final blur.
         return sqrt(self.basic_tr / 2 + self.final_tr * (self.final_tr + 1) / 3)
 
     @property

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from copy import deepcopy
 from enum import auto
-from math import comb
+from math import comb, sqrt
 from typing import Any, Literal, Protocol, Self, TypedDict, overload
 
 from jetpytools import CustomIntEnum, CustomValueError, FuncExcept, cachedproperty, fallback, normalize_seq, to_arr
@@ -588,6 +588,10 @@ class _QTGMCBuilder:
 
         return self
 
+    @property
+    def _temporal_blur_variance(self) -> float:
+        return sqrt(self.basic_tr / 2 + self.final_tr * (self.final_tr + 1) / 3)
+
     def source_match(
         self,
         *,
@@ -711,7 +715,8 @@ class _QTGMCBuilder:
 
         Args:
             strength: Sharpening strength. Higher values result in more sharpening. Defaults to 1 when
-                [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0, and 0 otherwise.
+                [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is `0`, and 0
+                otherwise.
             offset: Shifts the unsharpen blur source to the vertical min/max average ± this value (8-bit). Smaller
                 values result in more vertical sharpening. Passing a tuple of values results in asymmetric offsetting.
                 `False` disables range limiting. Defaults to 1.
@@ -720,7 +725,9 @@ class _QTGMCBuilder:
 
         self.sharpen_strength = strength
         self.sharpen_offset = offset is not False and normalize_seq(offset, 2)
-        self.sharpen_thin = thin
+        # Premultiply thin strength by the inverse L2 norm of the binomial blurs used in the algorithm.
+        # After multiplication, thin = 1.0 means edges found by median filtering are merged at full strength.
+        self.sharpen_thin = thin * 32 / sqrt(105)
 
         if mode is not None and not mode.value:  # TODO: remove
             self.sharpen_offset = False
@@ -738,11 +745,11 @@ class _QTGMCBuilder:
     @property
     def _sharpening_enabled(self) -> bool:
         return bool(
-            (self.sharpen_strength or self.sharpen_thin)
-            and (self.back_blend_mode is self.BackBlendMode.NONE or self.back_blend_sigma)
+            ((self.sharpen_strength and self._temporal_blur_variance) or self.sharpen_thin)
+            and (self.back_blend_mode is self.BackBlendMode.NONE or self.back_blend_scale)
         )
 
-    def back_blend(self, *, mode: BackBlendMode = BackBlendMode.BOTH, sigma: float = 1.4) -> Self:
+    def back_blend(self, *, mode: BackBlendMode = BackBlendMode.BOTH, scale: float = 2) -> Self:
         """
         Configures parameters for back-blending.
 
@@ -755,16 +762,32 @@ class _QTGMCBuilder:
                 high-frequency edge sharpening.
 
         Args:
-            mode: When to back-blend the (blurred) difference between the pre- and post-sharpened clips. Defaults to
-                BackBlendMode.BOTH.
-            sigma: Gaussian blur sigma applied to the pre- and post-sharpening difference. Lower values dampen
-                sharpening more aggressively. Defaults to 1.4.
+            mode: When to back-blend the (blurred) sharpening difference. Defaults to BackBlendMode.BOTH.
+            scale: Scale factor for the Gaussian blur sigma applied to the sharpening difference. Lower values dampen
+                sharpening more aggressively. Defaults to 2.
         """
 
         self.back_blend_mode = mode
-        self.back_blend_sigma = sigma
+        self.back_blend_scale = scale
 
         return self
+
+    @property
+    def back_blend_scale(self) -> float:
+        if not self._back_blend_scale:
+            return 0
+
+        passes = 1 + bool(
+            self.back_blend_mode is self.BackBlendMode.BOTH
+            and self.sharpen_limit_mode.is_presmooth
+            and self.sharpen_limit_radius
+        )
+
+        return self._temporal_blur_variance * (self._back_blend_scale / sqrt(passes))
+
+    @back_blend_scale.setter
+    def back_blend_scale(self, value: float) -> None:
+        self._back_blend_scale = value
 
     def sharpen_limit(
         self,
@@ -790,7 +813,7 @@ class _QTGMCBuilder:
         Args:
             mode: How and when to apply limiting to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen]. Defaults
                 to SharpenLimitMode.TEMPORAL_PRESMOOTH when
-                [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0 and
+                [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is `0` and
                 SharpenLimitMode.NONE otherwise.
             radius: Radius of the sharpness limiting. Larger values allow more sharpening. Defaults to 1.
             clamp: How much undershoot/overshoot to allow (8-bit). Larger values result in less limiting. Passing a
@@ -1052,7 +1075,7 @@ class QTGMCGraph(VSObject):
             binomial_coeff = comb(tr_f, tr)
             error_adj = tr_s / (binomial_coeff + self.settings.source_match_similarity * (tr_s - binomial_coeff))
 
-            return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=error_adjustment)
+            return unsharpen(ref, error_adj, clip, func=error_adjustment)
 
         if self.mode is not self.Mode.DESHIMMER:
             clip = reinterlace(clip, self.tff, self._source_match)
@@ -1116,7 +1139,7 @@ class QTGMCGraph(VSObject):
     def _sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
         resharp = clip
 
-        if self.settings.sharpen_strength:
+        if self.settings.sharpen_strength and self.settings._temporal_blur_variance:
             if self.settings.sharpen_offset is not False:
                 dark_offset, bright_offset = self.settings.sharpen_offset
 
@@ -1134,7 +1157,7 @@ class QTGMCGraph(VSObject):
             resharp = unsharpen(
                 clip,
                 self.settings.sharpen_strength,
-                BlurMatrix.BINOMIAL()(resharp, func=self._sharpen),
+                gauss_blur(resharp, self.settings._temporal_blur_variance),
                 func=self._sharpen,
             )
 
@@ -1152,7 +1175,7 @@ class QTGMCGraph(VSObject):
         return resharp
 
     def _back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
-        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_sigma))
+        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_scale))
 
     def _sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
         undershoot, overshoot = self.settings.sharpen_limit_clamp
@@ -1363,13 +1386,16 @@ class QTGMCGraph(VSObject):
 
                     noise_gen = Grainer.GAUSS(
                         noise,
-                        ((0.5 * 255) / 3) ** 2,  # 3σ rule.  # noqa: RUF003
+                        # Use the maximum variance that satisfies the 3-sigma rule.
+                        ((0.5 * 255) / 3) ** 2,
                         protect_edges=False,
                         protect_neutral_chroma=False,
                         neutral_out=True,
                     )
-                    noise_gen = norm_expr(  # Off-center neutral in int formats prevents the scale from reaching 1.
+                    noise_gen = norm_expr(
                         [noise_max, noise_min, noise_gen],
+                        # Limitation: This gain map can never reach 1.0 with integer formats.
+                        # Peak gain at 8-bit: (255 - 128) / 256 + 0.5 = ~0.996.
                         "y x y - z neutral - range_size / 0.5 + * +",
                         func=self.func,
                     )

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1537,11 +1537,20 @@ class QTempGaussMC(_QTGMCBuilder):
     processing capabilities, support for repair of progressive material, precision source matching, shutter speed
     simulation, and more.
 
-    Originally based on TempGaussMC by Didée.
+    Originally based on QTGMC by Vit and TempGaussMC by Didée
 
-    Basic Usage:
+    Usage examples:
+        - Basic call with defaults:
         ```python
-        deinterlace = QTempGaussMC().deinterlace(clip)
+        deinterlaced = QTempGaussMC().deinterlace(clip)
+        ```
+        - Using `EEDI3` for interpolation:
+        ```python
+        deinterlaced = QTempGaussMC().basic(bobber=EEDI3()).deinterlace(clip)
+        ```
+        - Enabling lossless and increasing final `tr`:
+        ```python
+        deinterlaced = QTempGaussMC().lossless(QTempGaussMC.LosslessMode.PRESHARPEN).final(tr=2).deinterlace(clip)
         ```
 
     Additional Usage Info: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -407,7 +407,7 @@ class _QTGMCBuilder:
                 precision without reducing denoising effectiveness. Defaults to 1.
             thsad_recalc: Only poor-quality new vectors with a SAD above this value will be re-estimated by motion
                 search. Only active when refine is used. Defaults to
-                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `thsad` / 2.
+                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `thsad / 2`.
             thscd: Scene-change detection thresholds:
 
                    - First value: SAD threshold for considering a block changed between frames.
@@ -504,22 +504,6 @@ class _QTGMCBuilder:
 
         return self
 
-    @property
-    def _mc_denoise_tr(self) -> int:
-        return (
-            self.denoise_tr
-            if self.denoise_mc_denoise and (self.denoise_full_denoise or self._noise_restore_enabled)
-            else 0
-        )
-
-    @property
-    def _noise_restore_enabled(self) -> bool:
-        return bool(self.basic_noise_restore or self.final_noise_restore)
-
-    @property
-    def _stabilization_enabled(self) -> bool:
-        return self.denoise_stabilize is not False and self._noise_restore_enabled
-
     def basic(
         self,
         *,
@@ -588,18 +572,14 @@ class _QTGMCBuilder:
 
         return self
 
-    @property
-    def _temporal_blur_variance(self) -> float:
-        return sqrt(self.basic_tr / 2 + self.final_tr * (self.final_tr + 1) / 3)
-
     def source_match(
         self,
         *,
         iterations: Literal[0, 1, 2, 3] = 0,
         bobber: BobberLike | None = None,
         tr: int = 1,
-        similarity: float = 0.5,
         enhance: float = 0.5,
+        similarity: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
         mode: SourceMatchMode | None = None,
     ) -> Self:
@@ -615,8 +595,8 @@ class _QTGMCBuilder:
             - Detail enhancement: Optionally applies unsharpening to the result when `enhance` is used.
             - Residual refinement pass: For multiple iterations, isolates the difference between the original input and
                 the current matched clip, interpolates and smooths this residual error (applying an additional
-                error-adjustment pass if `iterations` > 2), and merges it back to restore fine detail missed during the
-                initial pass.
+                error-adjustment pass if `iterations` > `2`), and merges it back to restore fine detail missed during
+                the initial pass.
 
         Note:
             - When source matching is used:
@@ -627,24 +607,24 @@ class _QTGMCBuilder:
 
         Args:
             iterations: Number of source match iterations to perform. Higher values are slower and more accurate. Using
-                2 or 3 iterations restores almost exact source detail but is sensitive to noise and introduces
-                occasional aliasing (to a lesser extent for 3). Requires
-                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `tr` > 0 Defaults to 0.
-            bobber: Bobber to use for refined spatial interpolation. Only used for `iterations` > 1. Defaults to
+                `2` or `3` iterations restores almost exact source detail but is sensitive to noise and introduces
+                occasional aliasing (to a lesser extent for `3`). Requires
+                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `tr` > `0` Defaults to 0.
+            bobber: Bobber to use for refined spatial interpolation. Only used for `iterations` > `1`. Defaults to
                 [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `bobber`.
             tr: Temporal radius of the refinement motion-compensated binomial blur. Larger values reduce more shimmer
-                but can introduce blurring and ghosting. Only used for `iterations` > 1. Defaults to 1.
+                but can introduce blurring and ghosting. Only used for `iterations` > `1`. Defaults to 1.
+            enhance: Enhances detail found by `iterations` > `1`. Higher values exaggerate detail more. Defaults to 0.5.
             similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
                 Defaults to 0.5.
-            enhance: Enhances detail found by `iterations` > 1. Higher values exaggerate detail more. Defaults to 0.5.
             degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
         """
 
         self.source_match_iterations = iterations
         self.source_match_bobber = bobber
         self.source_match_tr = tr
-        self.source_match_similarity = similarity
         self.source_match_enhance = enhance
+        self.source_match_similarity = similarity
         self.source_match_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
 
         if mode is not None:  # TODO: remove
@@ -666,10 +646,6 @@ class _QTGMCBuilder:
             self._source_match_bobber = deepcopy(value)
         else:
             self._source_match_bobber = Bobber.ensure_obj(value, self.__class__)
-
-    @property
-    def _source_match_enabled(self) -> bool:
-        return bool(self.source_match_iterations and self.basic_tr)
 
     def lossless(self, *, mode: LosslessMode = LosslessMode.NONE, anti_comb: bool = True) -> Self:
         """
@@ -742,13 +718,6 @@ class _QTGMCBuilder:
     def sharpen_strength(self, value: float | None) -> None:
         self._sharpen_strength = value
 
-    @property
-    def _sharpening_enabled(self) -> bool:
-        return bool(
-            ((self.sharpen_strength and self._temporal_blur_variance) or self.sharpen_thin)
-            and (self.back_blend_mode is self.BackBlendMode.NONE or self.back_blend_scale)
-        )
-
     def back_blend(self, *, mode: BackBlendMode = BackBlendMode.BOTH, scale: float = 2) -> Self:
         """
         Configures parameters for back-blending.
@@ -771,20 +740,6 @@ class _QTGMCBuilder:
         self.back_blend_scale = scale
 
         return self
-
-    @property
-    def back_blend_scale(self) -> float:
-        passes = 1 + bool(
-            self.back_blend_mode is self.BackBlendMode.BOTH
-            and self.sharpen_limit_mode.is_presmooth
-            and self.sharpen_limit_radius
-        )
-
-        return self._temporal_blur_variance * (self._back_blend_scale / sqrt(passes))
-
-    @back_blend_scale.setter
-    def back_blend_scale(self, value: float) -> None:
-        self._back_blend_scale = value
 
     def sharpen_limit(
         self,
@@ -836,14 +791,6 @@ class _QTGMCBuilder:
     @sharpen_limit_mode.setter
     def sharpen_limit_mode(self, value: SharpenLimitMode | None) -> None:
         self._sharpen_limit_mode = value
-
-    @property
-    def _sharpness_limiting_enabled(self) -> bool:
-        return bool(
-            self.sharpen_limit_mode is not self.SharpenLimitMode.NONE
-            and self.sharpen_limit_radius
-            and self._sharpening_enabled
-        )
 
     def final(
         self,
@@ -937,6 +884,55 @@ class _QTGMCBuilder:
 
         return self
 
+    @property
+    def _noise_restore_enabled(self) -> bool:
+        return bool(self.basic_noise_restore or self.final_noise_restore)
+
+    @property
+    def _mc_denoise_tr(self) -> int:
+        return (
+            self.denoise_tr
+            if self.denoise_mc_denoise and (self.denoise_full_denoise or self._noise_restore_enabled)
+            else 0
+        )
+
+    @property
+    def _stabilization_enabled(self) -> bool:
+        return self.denoise_stabilize is not False and self._noise_restore_enabled
+
+    @property
+    def _source_match_enabled(self) -> bool:
+        return bool(self.source_match_iterations and self.basic_tr)
+
+    @property
+    def _sharpen_sigma(self) -> float:
+        return sqrt(self.basic_tr / 2 + self.final_tr * (self.final_tr + 1) / 3)
+
+    @property
+    def _sharpening_enabled(self) -> bool:
+        return bool(
+            ((self.sharpen_strength and self._sharpen_sigma) or self.sharpen_thin)
+            and (self.back_blend_mode is self.BackBlendMode.NONE or self._back_blend_sigma)
+        )
+
+    @property
+    def _back_blend_sigma(self) -> float:
+        passes = 1 + bool(
+            self.back_blend_mode is self.BackBlendMode.BOTH
+            and self.sharpen_limit_mode.is_presmooth
+            and self.sharpen_limit_radius
+        )
+
+        return self._sharpen_sigma * (self.back_blend_scale / sqrt(passes))
+
+    @property
+    def _sharpness_limiting_enabled(self) -> bool:
+        return bool(
+            self.sharpen_limit_mode is not self.SharpenLimitMode.NONE
+            and self.sharpen_limit_radius
+            and self._sharpening_enabled
+        )
+
 
 class QTGMCGraph(VSObject):
     """
@@ -947,6 +943,20 @@ class QTGMCGraph(VSObject):
     allows the intermediate clips and motion vectors used to produce the output to be inspected or reused.
 
     Returned graphs are frozen after evaluation so that access is limited to stages used to construct the output.
+
+    Usage examples:
+        - Reusing the [MVTools][vsdenoise.mvtools.mvtools.MVTools] object:
+        ```python
+        qtgmc = vsdeinterlace.QTempGaussMC()
+        deinterlaced, graph = qtgmc.deinterlace(clip, return_graph=True)
+        mv = graph.mv
+        ```
+        - Inspecting the output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter]:
+        ```python
+        qtgmc = vsdeinterlace.QTempGaussMC()
+        deinterlaced, graph = qtgmc.deinterlace(clip, return_graph=True)
+        prefilter = graph.prefilter
+        ```
     """
 
     class Mode(CustomIntEnum):
@@ -1015,7 +1025,8 @@ class QTGMCGraph(VSObject):
             func: Function returned for custom error handling. This should only be set by VS package developers.
 
         Raises:
-            UnsupportedFieldBasedError: If `clip` is progressive and `mode` is not `Mode.DESHIMMER`.
+            UnsupportedFieldBasedError: If `clip` is [FieldBased.PROGRESSIVE][vstools.FieldBased.PROGRESSIVE] and `mode`
+                is not `Mode.DESHIMMER`.
         """
 
         self.clip = clip
@@ -1041,197 +1052,6 @@ class QTGMCGraph(VSObject):
             self.__dict__[cachedproperty.cache_key] = self._FrozenCache(cache)
 
         return self
-
-    def _interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
-        if self.mode is not self.Mode.DESHIMMER:
-            clip = bobber.bob(clip, tff=self.tff)
-
-        return clip
-
-    def _binomial_degrain(self, clip: vs.VideoNode, tr: int, **degrain_args: Any) -> vs.VideoNode:
-        if not tr:
-            return clip
-
-        return self.mv.degrain(
-            clip,
-            tr=tr,
-            thsad=self.settings.basic_thsad,
-            thsad2=self.settings.basic_thsad2,
-            thscd=self.settings.analyze_thscd,
-            weights=BlurMatrix.BINOMIAL(radius=tr),
-            **degrain_args,
-        )
-
-    def _source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
-        def error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
-            if not tr:
-                return ref
-
-            tr_f = 2 * tr - 1
-            tr_s = 2**tr_f
-            binomial_coeff = comb(tr_f, tr)
-            error_adj = tr_s / (binomial_coeff + self.settings.source_match_similarity * (tr_s - binomial_coeff))
-
-            return unsharpen(ref, error_adj, clip, func=error_adjustment)
-
-        if self.mode is not self.Mode.DESHIMMER:
-            clip = reinterlace(clip, self.tff, self._source_match)
-
-        adjusted = error_adjustment(self.bob_input, clip, self.settings.basic_tr)
-        new_bobbed = self._interpolate(adjusted, self.settings.basic_bobber)
-        matched = self._binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
-
-        if self.settings.source_match_iterations > 1:
-            if self.settings.source_match_enhance:
-                matched = unsharpen(
-                    matched, self.settings.source_match_enhance, BlurMatrix.BINOMIAL(), func=self._source_match
-                )
-
-            if self.mode is not self.Mode.DESHIMMER:
-                clip = reinterlace(matched, self.tff, self._source_match)
-            else:
-                clip = matched
-
-            diff = self.bob_input.std.MakeDiff(clip)
-            refine_bobbed = self._interpolate(diff, self.settings.source_match_bobber)
-            refine_matched = self._binomial_degrain(
-                refine_bobbed, self.settings.source_match_tr, **self.settings.source_match_degrain_args
-            )
-
-            if self.settings.source_match_iterations > 2:
-                refine_adjusted = error_adjustment(refine_bobbed, refine_matched, self.settings.source_match_tr)
-                refine_matched = self._binomial_degrain(
-                    refine_adjusted, self.settings.source_match_tr, **self.settings.source_match_degrain_args
-                )
-
-            return matched.std.MergeDiff(refine_matched)
-
-        return matched
-
-    def _lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
-        if self.mode is self.Mode.DESHIMMER or clip is self.bobbed:
-            return clip
-
-        fields_src = self.denoise.std.SeparateFields(self.tff.is_tff)
-        if self.mode is self.Mode.REPAIR:
-            fields_src = fields_src.std.SelectEvery(4, (0, 3))
-        fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
-
-        woven = reweave(fields_src, fields_flt, self.tff.field, self._lossless)
-
-        if self.settings.lossless_anti_comb:
-            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self._lossless).std.MakeDiff(woven)
-            fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
-
-            cleaned_diff = norm_expr(
-                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self._lossless), fields_diff],
-                "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
-                func=self._lossless,
-            )
-            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
-            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self._lossless)
-
-        return FieldBased.PROGRESSIVE.apply(woven)
-
-    def _sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
-        resharp = clip
-
-        if self.settings.sharpen_strength and self.settings._temporal_blur_variance:
-            if self.settings.sharpen_offset is not False:
-                dark_offset, bright_offset = self.settings.sharpen_offset
-
-                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self._sharpen)
-                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self._sharpen)
-
-                resharp = norm_expr(
-                    [clip, source_min, source_max],
-                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
-                    dark_offset=scale_delta(dark_offset, 8, self.clip),
-                    bright_offset=scale_delta(bright_offset, 8, self.clip),
-                    func=self._sharpen,
-                )
-
-            resharp = unsharpen(
-                clip,
-                self.settings.sharpen_strength,
-                gauss_blur(resharp, self.settings._temporal_blur_variance),
-                func=self._sharpen,
-            )
-
-        if self.settings.sharpen_thin:
-            median_diff = median_blur(clip, mode=ConvMode.VERTICAL, func=self._sharpen).std.MakeDiff(clip)
-            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self._sharpen)
-
-            resharp = norm_expr(
-                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self._sharpen), blurred_diff],
-                "y neutral - dup abs z neutral - abs > swap {thin} * x + x ?",
-                thin=self.settings.sharpen_thin,
-                func=self._sharpen,
-            )
-
-        return resharp
-
-    def _back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
-        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_scale))
-
-    def _sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
-        undershoot, overshoot = self.settings.sharpen_limit_clamp
-
-        if self.settings.sharpen_limit_mode.is_spatial:
-            if self.settings.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
-                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
-            else:
-                inpand = Morpho.minimum(
-                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self._sharpen_limit
-                )
-                expand = Morpho.maximum(
-                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self._sharpen_limit
-                )
-                clip = norm_expr(
-                    [clip, inpand, expand],
-                    "x y {undershoot} - z {overshoot} + clamp",
-                    undershoot=scale_delta(undershoot, 8, self.clip),
-                    overshoot=scale_delta(overshoot, 8, self.clip),
-                    func=self._sharpen_limit,
-                )
-        elif self.settings.sharpen_limit_mode.is_temporal:
-            clip = mc_clamp(
-                clip,
-                self.bobbed,
-                self.mv,
-                (undershoot, overshoot),
-                self._sharpen_limit,
-                tr=self.settings.sharpen_limit_radius,
-                thscd=self.settings.analyze_thscd,
-                **self.settings.sharpen_limit_comp_args,
-            )
-
-        return clip
-
-    def _noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
-        if restore:
-            clip = norm_expr(
-                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self._noise_restore
-            )
-
-        return clip
-
-    @cachedproperty
-    def _repair_mask_enabled(self) -> bool:
-        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml") != 0)
-
-    @cachedproperty
-    def _motion_blur_level(self) -> float:
-        if self.settings.motion_blur_shutter_angle is False:
-            return 0
-
-        angle_in, angle_out = self.settings.motion_blur_shutter_angle
-
-        return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
-
-    @cachedproperty
-    def _motion_blur_fps_divisor(self) -> int:
-        return 1 if self.mode is self.Mode.BOB else self.settings.motion_blur_fps_divisor
 
     @cachedproperty
     def draft(self) -> vs.VideoNode:
@@ -1337,27 +1157,10 @@ class QTGMCGraph(VSObject):
         return mv
 
     @cachedproperty
-    def _run_denoiser(self) -> vs.VideoNode:
-        if self.settings._mc_denoise_tr:
-            denoised = self.mv.compensate(
-                tr=self.settings.denoise_tr,
-                thscd=self.settings.analyze_thscd,
-                temporal_func=lambda clip: self.settings.denoise_func(clip, tr=self.settings.denoise_tr),
-                **self.settings.denoise_func_comp_args,
-            )
-        else:
-            denoised = self.settings.denoise_func(self.draft, tr=self.settings.denoise_tr)
-
-        if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
-            denoised = reinterlace(denoised, self.tff, self.func)
-
-        return denoised
-
-    @cachedproperty
     def denoise(self) -> vs.VideoNode:
         """Output of [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
 
-        return self._run_denoiser if self.settings.denoise_full_denoise else self.clip
+        return self._apply_denoise if self.settings.denoise_full_denoise else self.clip
 
     @cachedproperty
     def noise(self) -> vs.VideoNode:
@@ -1367,7 +1170,7 @@ class QTGMCGraph(VSObject):
         Only available when using noise restoration.
         """
 
-        noise = self.clip.std.MakeDiff(self._run_denoiser)
+        noise = self.clip.std.MakeDiff(self._apply_denoise)
 
         if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
             match self.settings.denoise_deint:
@@ -1549,6 +1352,214 @@ class QTGMCGraph(VSObject):
             blurred = blurred[:: self._motion_blur_fps_divisor]
 
         return blurred
+
+    @cachedproperty
+    def _apply_denoise(self) -> vs.VideoNode:
+        if self.settings._mc_denoise_tr:
+            denoised = self.mv.compensate(
+                tr=self.settings.denoise_tr,
+                thscd=self.settings.analyze_thscd,
+                temporal_func=lambda clip: self.settings.denoise_func(clip, tr=self.settings.denoise_tr),
+                **self.settings.denoise_func_comp_args,
+            )
+        else:
+            denoised = self.settings.denoise_func(self.draft, tr=self.settings.denoise_tr)
+
+        if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
+            denoised = reinterlace(denoised, self.tff, self.func)
+
+        return denoised
+
+    @cachedproperty
+    def _repair_mask_enabled(self) -> bool:
+        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml") != 0)
+
+    @cachedproperty
+    def _motion_blur_fps_divisor(self) -> int:
+        return 1 if self.mode is self.Mode.BOB else self.settings.motion_blur_fps_divisor
+
+    @cachedproperty
+    def _motion_blur_level(self) -> float:
+        if self.settings.motion_blur_shutter_angle is False:
+            return 0
+
+        angle_in, angle_out = self.settings.motion_blur_shutter_angle
+
+        return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
+
+    def _interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
+        if self.mode is not self.Mode.DESHIMMER:
+            clip = bobber.bob(clip, tff=self.tff)
+
+        return clip
+
+    def _binomial_degrain(self, clip: vs.VideoNode, tr: int, **degrain_args: Any) -> vs.VideoNode:
+        if not tr:
+            return clip
+
+        return self.mv.degrain(
+            clip,
+            tr=tr,
+            thsad=self.settings.basic_thsad,
+            thsad2=self.settings.basic_thsad2,
+            thscd=self.settings.analyze_thscd,
+            weights=BlurMatrix.BINOMIAL(radius=tr),
+            **degrain_args,
+        )
+
+    def _source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
+        def error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
+            if not tr:
+                return ref
+
+            tr_f = 2 * tr - 1
+            tr_s = 2**tr_f
+            binomial_coeff = comb(tr_f, tr)
+            error_adj = tr_s / (binomial_coeff + self.settings.source_match_similarity * (tr_s - binomial_coeff))
+
+            return unsharpen(ref, error_adj, clip, func=error_adjustment)
+
+        if self.mode is not self.Mode.DESHIMMER:
+            clip = reinterlace(clip, self.tff, self._source_match)
+
+        adjusted = error_adjustment(self.bob_input, clip, self.settings.basic_tr)
+        new_bobbed = self._interpolate(adjusted, self.settings.basic_bobber)
+        matched = self._binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
+
+        if self.settings.source_match_iterations > 1:
+            if self.settings.source_match_enhance:
+                matched = unsharpen(
+                    matched, self.settings.source_match_enhance, BlurMatrix.BINOMIAL(), func=self._source_match
+                )
+
+            if self.mode is not self.Mode.DESHIMMER:
+                clip = reinterlace(matched, self.tff, self._source_match)
+            else:
+                clip = matched
+
+            diff = self.bob_input.std.MakeDiff(clip)
+            refine_bobbed = self._interpolate(diff, self.settings.source_match_bobber)
+            refine_matched = self._binomial_degrain(
+                refine_bobbed, self.settings.source_match_tr, **self.settings.source_match_degrain_args
+            )
+
+            if self.settings.source_match_iterations > 2:
+                refine_adjusted = error_adjustment(refine_bobbed, refine_matched, self.settings.source_match_tr)
+                refine_matched = self._binomial_degrain(
+                    refine_adjusted, self.settings.source_match_tr, **self.settings.source_match_degrain_args
+                )
+
+            return matched.std.MergeDiff(refine_matched)
+
+        return matched
+
+    def _lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
+        if self.mode is self.Mode.DESHIMMER or clip is self.bobbed:
+            return clip
+
+        fields_src = self.denoise.std.SeparateFields(self.tff.is_tff)
+        if self.mode is self.Mode.REPAIR:
+            fields_src = fields_src.std.SelectEvery(4, (0, 3))
+        fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
+
+        woven = reweave(fields_src, fields_flt, self.tff.field, self._lossless)
+
+        if self.settings.lossless_anti_comb:
+            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self._lossless).std.MakeDiff(woven)
+            fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
+
+            cleaned_diff = norm_expr(
+                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self._lossless), fields_diff],
+                "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
+                func=self._lossless,
+            )
+            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
+            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self._lossless)
+
+        return FieldBased.PROGRESSIVE.apply(woven)
+
+    def _sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
+        resharp = clip
+
+        if self.settings.sharpen_strength and self.settings._sharpen_sigma:
+            if self.settings.sharpen_offset is not False:
+                dark_offset, bright_offset = self.settings.sharpen_offset
+
+                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self._sharpen)
+                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self._sharpen)
+
+                resharp = norm_expr(
+                    [clip, source_min, source_max],
+                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
+                    dark_offset=scale_delta(dark_offset, 8, self.clip),
+                    bright_offset=scale_delta(bright_offset, 8, self.clip),
+                    func=self._sharpen,
+                )
+
+            resharp = unsharpen(
+                clip,
+                self.settings.sharpen_strength,
+                gauss_blur(resharp, self.settings._sharpen_sigma),
+                func=self._sharpen,
+            )
+
+        if self.settings.sharpen_thin:
+            median_diff = median_blur(clip, mode=ConvMode.VERTICAL, func=self._sharpen).std.MakeDiff(clip)
+            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self._sharpen)
+
+            resharp = norm_expr(
+                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self._sharpen), blurred_diff],
+                "y neutral - dup abs z neutral - abs > swap {thin} * x + x ?",
+                thin=self.settings.sharpen_thin,
+                func=self._sharpen,
+            )
+
+        return resharp
+
+    def _back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
+        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings._back_blend_sigma))
+
+    def _sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
+        undershoot, overshoot = self.settings.sharpen_limit_clamp
+
+        if self.settings.sharpen_limit_mode.is_spatial:
+            if self.settings.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
+                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
+            else:
+                inpand = Morpho.minimum(
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self._sharpen_limit
+                )
+                expand = Morpho.maximum(
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self._sharpen_limit
+                )
+                clip = norm_expr(
+                    [clip, inpand, expand],
+                    "x y {undershoot} - z {overshoot} + clamp",
+                    undershoot=scale_delta(undershoot, 8, self.clip),
+                    overshoot=scale_delta(overshoot, 8, self.clip),
+                    func=self._sharpen_limit,
+                )
+        elif self.settings.sharpen_limit_mode.is_temporal:
+            clip = mc_clamp(
+                clip,
+                self.bobbed,
+                self.mv,
+                (undershoot, overshoot),
+                self._sharpen_limit,
+                tr=self.settings.sharpen_limit_radius,
+                thscd=self.settings.analyze_thscd,
+                **self.settings.sharpen_limit_comp_args,
+            )
+
+        return clip
+
+    def _noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
+        if restore:
+            clip = norm_expr(
+                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self._noise_restore
+            )
+
+        return clip
 
 
 class QTempGaussMC(_QTGMCBuilder):

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -121,6 +121,64 @@ class _QTGMCBuilder:
         Generate fresh noise lines.
         """
 
+    class LosslessMode(CustomIntEnum):
+        NONE = auto()
+        """
+        Do not restore the original fields.
+        """
+
+        PRESHARPEN = auto()
+        """
+        Restore the original fields prior to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen].
+
+        Provides near-lossless fidelity, mitigates most artifacts, and retains sharpness control.
+        """
+
+        POSTSMOOTH = auto()
+        """
+        Restore the original fields after [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
+
+        Provides true lossless output, given [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] `noise_restore` is
+        not used. Offers minimal sharpness control and tends to have more significant artifacts.
+        """
+
+    class BackBlendMode(CustomIntEnum):
+        NONE = auto()
+        """
+        No back-blending.
+
+        Keeps all [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen] frequencies.
+        """
+
+        PRELIMIT = auto()
+        """
+        Back-blending prior to [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
+
+        Provides the weakest low-frequency dampening.
+        """
+
+        POSTLIMIT = auto()
+        """
+        Back-blending after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
+
+        Provides the strongest low-frequency dampening.
+
+        Note:
+            Identical to `PRELIMIT` when using `SharpenLimitMode.NONE`, `SharpenLimitMode.SPATIAL_POSTSMOOTH` or
+            `SharpenLimitMode.TEMPORAL_POSTSMOOTH`.
+        """
+
+        BOTH = auto()
+        """
+        Back-blending both before and after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
+
+        Provides a balanced middle ground between `PRELIMIT` and `POSTLIMIT` dampening.
+
+        Note:
+            Identical to `PRELIMIT` when using `SharpenLimitMode.NONE`, `SharpenLimitMode.SPATIAL_POSTSMOOTH` or
+            `SharpenLimitMode.TEMPORAL_POSTSMOOTH`.
+        """
+
     class SharpenLimitMode(CustomIntEnum):
         NONE = auto()
         """
@@ -175,69 +233,11 @@ class _QTGMCBuilder:
         def is_postsmooth(self) -> bool:
             return self in (self.SPATIAL_POSTSMOOTH, self.TEMPORAL_POSTSMOOTH)
 
-    class BackBlendMode(CustomIntEnum):
-        NONE = auto()
-        """
-        No back-blending.
-
-        Keeps all [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen] frequencies.
-        """
-
-        PRELIMIT = auto()
-        """
-        Back-blending prior to [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
-
-        Provides the weakest low-frequency dampening.
-        """
-
-        POSTLIMIT = auto()
-        """
-        Back-blending after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
-
-        Provides the strongest low-frequency dampening.
-
-        Note:
-            Identical to `PRELIMIT` when using `SharpenLimitMode.NONE`, `SharpenLimitMode.SPATIAL_POSTSMOOTH` or
-            `SharpenLimitMode.TEMPORAL_POSTSMOOTH`.
-        """
-
-        BOTH = auto()
-        """
-        Back-blending both before and after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
-
-        Provides a balanced middle ground between `PRELIMIT` sharpening strength and `POSTLIMIT` dampening.
-
-        Note:
-            Identical to `PRELIMIT` when using `SharpenLimitMode.NONE`, `SharpenLimitMode.SPATIAL_POSTSMOOTH` or
-            `SharpenLimitMode.TEMPORAL_POSTSMOOTH`.
-        """
-
-    class LosslessMode(CustomIntEnum):
-        NONE = auto()
-        """
-        Do not restore the original fields.
-        """
-
-        PRESHARPEN = auto()
-        """
-        Restore the original fields prior to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen].
-
-        Provides near-lossless fidelity, mitigates most artifacts, and retains sharpness control.
-        """
-
-        POSTSMOOTH = auto()
-        """
-        Restore the original fields after [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
-
-        Provides true lossless output, given [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] `noise_restore` is
-        not used. Offers minimal sharpness control and tends to have more significant artifacts.
-        """
-
     def __init__(self, **kwargs: Any) -> None:
         """
         Args:
             **kwargs: Additional arguments to be passed to the parameter category methods. Separate the method name
-                from its argument with two underscores, for example `sharpen_limit__mode`.
+                from its argument with two underscores, for example: `sharpen_limit__mode`.
         """
 
         settings_methods = (
@@ -276,7 +276,7 @@ class _QTGMCBuilder:
         """
         Configures parameters for the prefilter stage.
 
-        Prepares a suitable search clip to be provided for motion analysis purposes.
+        Prepares a suitable search clip to be provided for motion analysis.
 
         High-level overview:
             - ([QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]) Draft bobbed clip generation:
@@ -284,9 +284,9 @@ class _QTGMCBuilder:
                 temporal instability known as bob shimmer.
             - ([QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]) Vertical spatial pre-filtering: Applies a
                 vertical binomial blur to filter out residual vertical artifacts.
-            - Temporal binomial blurring: Applies a temporal binomial blur to smooth
-                the draft clip, removing the shimmer, which prevents [MVTools][vsdenoise.mvtools.mvtools.MVTools] from
-                falsely latching onto the shimmer as motion (though this uncompensated blur introduces ghosting).
+            - Temporal binomial blurring: Applies a temporal binomial blur to smooth the draft clip, removing the
+                shimmer, which prevents [MVTools][vsdenoise.mvtools.mvtools.MVTools] from falsely latching onto the
+                shimmer as motion (though this uncompensated blur introduces ghosting).
             - Shimmer masking: Uses a specialized masking process to eliminate the introduced ghosting while retaining
                 the shimmer removal.
             - Gaussian blurring post-processing: Applies Gaussian blurring to lower high SAD values caused by sharp
@@ -456,7 +456,7 @@ class _QTGMCBuilder:
             func_comp_args: Additional arguments passed to
                 [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for denoising. Defaults to None.
             stabilize_comp_args: Additional arguments passed to
-                [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for noise stabilization. Defaults to
+                [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for stabilization. Defaults to
                 None.
         """
 
@@ -472,8 +472,12 @@ class _QTGMCBuilder:
         return self
 
     @property
-    def _denoise_enabled(self) -> bool:
-        return self.denoise_full_denoise or self._noise_restore_enabled
+    def _mc_denoise_tr(self) -> int:
+        return (
+            self.denoise_tr
+            if self.denoise_mc_denoise and (self.denoise_full_denoise or self._noise_restore_enabled)
+            else 0
+        )
 
     @property
     def _noise_restore_enabled(self) -> bool:
@@ -630,8 +634,7 @@ class _QTGMCBuilder:
         """
         Configures parameters for lossless processing.
 
-        Restoring original fields significantly improves fidelity, but may introduce minor shimmering, combing,
-        or noise.
+        Creates higher-fidelity output by restoring the original fields.
 
         High-level overview:
             - Source field weaving: Weaves the original fields together with the newly smoothed fields to preserve the
@@ -874,7 +877,7 @@ class _QTGMCBuilder:
         return self
 
 
-class _QTGMCRun:
+class _QTGMCGraph(VSObject):
     class Mode(CustomIntEnum):
         DEINTERLACE = auto()
         BOB = auto()
@@ -895,50 +898,10 @@ class _QTGMCRun:
         self.settings = settings
 
         if not self.tff.is_inter and self.mode is not self.Mode.DESHIMMER:
-            raise UnsupportedFieldBasedError("This method is incompatible with progressive video!", func)
-
-    @cachedproperty
-    def is_deinterlace(self) -> bool:
-        return self.tff.is_inter and not self.is_repair
-
-    @cachedproperty
-    def is_repair(self) -> bool:
-        return self.mode is self.Mode.REPAIR
-
-    @cachedproperty
-    def required_analyze_tr(self) -> int:
-        return max(
-            self.settings.analyze_force_tr,
-            self.settings.denoise_tr if self.settings.denoise_mc_denoise and self.settings._denoise_enabled else 0,
-            self.settings._stabilization_enabled,
-            self.settings.basic_tr,
-            self.repair_mask_enabled,
-            self.settings.source_match_tr
-            if self.settings.source_match_iterations > 1 and self.settings._source_match_enabled
-            else 0,
-            self.settings.sharpen_limit_radius
-            if self.settings.sharpen_limit_mode.is_temporal and self.settings._sharpness_limiting_enabled
-            else 0,
-            self.settings.final_tr,
-            bool(self.motion_blur_level),
-        )
-
-    @cachedproperty
-    def repair_mask_enabled(self) -> bool:
-        return bool(self.is_repair and self.settings.basic_mask_args.get("ml", 0))
-
-    @cachedproperty
-    def motion_blur_level(self) -> float:
-        angle_in, angle_out = self.settings.motion_blur_shutter_angle
-
-        return (angle_out * self.motion_blur_fps_divisor - angle_in) * 100 / 360
-
-    @cachedproperty
-    def motion_blur_fps_divisor(self) -> int:
-        return 1 if self.mode is self.Mode.BOB else self.settings.motion_blur_fps_divisor
+            raise UnsupportedFieldBasedError("This mode is incompatible with progressive video!", func)
 
     def interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
-        if self.tff.is_inter:
+        if self.mode is not self.Mode.DESHIMMER:
             clip = bobber.bob(clip, tff=self.tff)
 
         return clip
@@ -957,27 +920,197 @@ class _QTGMCRun:
             **degrain_args,
         )
 
-    def apply_prefilter(self) -> None:
-        if not (self.required_analyze_tr or self.settings._denoise_enabled):
-            return
+    def source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
+        def error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
+            if not tr:
+                return ref
 
-        self.draft = Catrom().bob(self.clip, tff=self.tff) if self.is_deinterlace else self.clip
+            tr_f = 2 * tr - 1
+            tr_s = 2**tr_f
+            binomial_coeff = comb(tr_f, tr)
+            error_adj = tr_s / (binomial_coeff + self.settings.source_match_similarity * (tr_s - binomial_coeff))
 
-        if not self.required_analyze_tr or self.settings.analyze_vectors:
-            return
+            return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=error_adjustment)
 
-        if self.is_repair:
-            search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self.apply_prefilter)
+        if self.mode is not self.Mode.DESHIMMER:
+            clip = reinterlace(clip, self.tff, self.source_match)
+
+        adjusted = error_adjustment(self.bob_input, clip, self.settings.basic_tr)
+        new_bobbed = self.interpolate(adjusted, self.settings.basic_bobber)
+        matched = self.binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
+
+        if self.settings.source_match_iterations > 1:
+            if self.settings.source_match_enhance:
+                matched = unsharpen(
+                    matched, self.settings.source_match_enhance, BlurMatrix.BINOMIAL(), func=self.source_match
+                )
+
+            if self.mode is not self.Mode.DESHIMMER:
+                clip = reinterlace(matched, self.tff, self.source_match)
+            else:
+                clip = matched
+
+            diff = self.bob_input.std.MakeDiff(clip)
+            refine_bobbed = self.interpolate(diff, self.settings.source_match_bobber)
+            refine_matched = self.binomial_degrain(
+                refine_bobbed, self.settings.source_match_tr, **self.settings.source_match_degrain_args
+            )
+
+            if self.settings.source_match_iterations > 2:
+                refine_adjusted = error_adjustment(refine_bobbed, refine_matched, self.settings.source_match_tr)
+                refine_matched = self.binomial_degrain(
+                    refine_adjusted, self.settings.source_match_tr, **self.settings.source_match_degrain_args
+                )
+
+            return matched.std.MergeDiff(refine_matched)
+
+        return matched
+
+    def lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
+        if self.mode is self.Mode.DESHIMMER or clip is self.bobbed:
+            return clip
+
+        fields_src = self.denoise.std.SeparateFields(self.tff.is_tff)
+        if self.mode is self.Mode.REPAIR:
+            fields_src = fields_src.std.SelectEvery(4, (0, 3))
+        fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
+
+        woven = reweave(fields_src, fields_flt, self.tff.field, self.lossless)
+
+        if self.settings.lossless_anti_comb:
+            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self.lossless).std.MakeDiff(woven)
+            fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
+
+            cleaned_diff = norm_expr(
+                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self.lossless), fields_diff],
+                "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
+                func=self.lossless,
+            )
+            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
+            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self.lossless)
+
+        return FieldBased.PROGRESSIVE.apply(woven)
+
+    def sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
+        resharp = clip
+
+        if self.settings.sharpen_strength:
+            if self.settings.sharpen_offset is not False:
+                dark_offset, bright_offset = self.settings.sharpen_offset
+
+                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self.sharpen)
+                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self.sharpen)
+
+                resharp = norm_expr(
+                    [clip, source_min, source_max],
+                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
+                    dark_offset=scale_delta(dark_offset, 8, self.clip),
+                    bright_offset=scale_delta(bright_offset, 8, self.clip),
+                    func=self.sharpen,
+                )
+
+            resharp = unsharpen(
+                clip,
+                self.settings.sharpen_strength,
+                BlurMatrix.BINOMIAL()(resharp, func=self.sharpen),
+                func=self.sharpen,
+            )
+
+        if self.settings.sharpen_thin:
+            median_diff = norm_expr(
+                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self.sharpen)],
+                "y x - {thin} * neutral +",
+                thin=self.settings.sharpen_thin,
+                func=self.sharpen,
+            )
+            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self.sharpen)
+
+            resharp = norm_expr(
+                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self.sharpen), blurred_diff],
+                "y neutral - dup abs z neutral - abs > swap x + x ?",
+                func=self.sharpen,
+            )
+
+        return resharp
+
+    def back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
+        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_sigma))
+
+    def sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
+        undershoot, overshoot = self.settings.sharpen_limit_clamp
+
+        if self.settings.sharpen_limit_mode.is_spatial:
+            if self.settings.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
+                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
+            else:
+                inpand = Morpho.minimum(
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self.sharpen_limit
+                )
+                expand = Morpho.maximum(
+                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self.sharpen_limit
+                )
+                clip = norm_expr(
+                    [clip, inpand, expand],
+                    "x y {undershoot} - z {overshoot} + clamp",
+                    undershoot=scale_delta(undershoot, 8, self.clip),
+                    overshoot=scale_delta(overshoot, 8, self.clip),
+                    func=self.sharpen_limit,
+                )
+        elif self.settings.sharpen_limit_mode.is_temporal:
+            clip = mc_clamp(
+                clip,
+                self.bobbed,
+                self.mv,
+                (undershoot, overshoot),
+                self.sharpen_limit,
+                tr=self.settings.sharpen_limit_radius,
+                thscd=self.settings.analyze_thscd,
+                **self.settings.sharpen_limit_comp_args,
+            )
+
+        return clip
+
+    def noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
+        if restore:
+            clip = norm_expr(
+                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self.noise_restore
+            )
+
+        return clip
+
+    @cachedproperty
+    def repair_mask_enabled(self) -> bool:
+        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml", 0))
+
+    @cachedproperty
+    def motion_blur_level(self) -> float:
+        angle_in, angle_out = self.settings.motion_blur_shutter_angle
+
+        return (angle_out * self.motion_blur_fps_divisor - angle_in) * 100 / 360
+
+    @cachedproperty
+    def motion_blur_fps_divisor(self) -> int:
+        return 1 if self.mode is self.Mode.BOB else self.settings.motion_blur_fps_divisor
+
+    @cachedproperty
+    def draft(self) -> vs.VideoNode:
+        if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
+            return Catrom().bob(self.clip, tff=self.tff)
+
+        return self.clip
+
+    @cachedproperty
+    def prefilter(self) -> vs.VideoNode:
+        if self.mode is self.Mode.REPAIR:
+            search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self.__class__)
         else:
             search = self.draft
 
         if self.settings.prefilter_tr:
             smoothed = BlurMatrix.BINOMIAL(self.settings.prefilter_tr, mode=ConvMode.TEMPORAL)(
-                sc_detect(search, self.settings.prefilter_sc_threshold), scenechange=True, func=self.apply_prefilter
+                sc_detect(search, self.settings.prefilter_sc_threshold), scenechange=True, func=self.__class__
             )
-            smoothed = mask_shimmer(
-                smoothed, search, **self.settings.prefilter_mask_shimmer_args, func=self.apply_prefilter
-            )
+            smoothed = mask_shimmer(smoothed, search, **self.settings.prefilter_mask_shimmer_args, func=self.__class__)
         else:
             smoothed = search
 
@@ -998,41 +1131,53 @@ class _QTGMCRun:
                 lim2=lim2,
                 lim3=lim3,
                 bias=self.settings.prefilter_bias,
-                func=self.apply_prefilter,
+                func=self.__class__,
             )
 
-        self.prefilter_output = prefilter_to_full_range(
-            blurred, func=self.apply_prefilter, **self.settings.prefilter_range_expansion_args
+        return prefilter_to_full_range(blurred, func=self.__class__, **self.settings.prefilter_range_expansion_args)
+
+    @cachedproperty
+    def mv(self) -> MVTools:
+        if not self.settings.analyze_vectors:
+            preset = {**self.settings.analyze_preset, "search_clip": self.prefilter}
+        else:
+            preset = self.settings.analyze_preset
+
+        mv = MVTools(self.draft, vectors=self.settings.analyze_vectors, **preset)
+
+        if self.settings.analyze_vectors:
+            return mv
+
+        tr = max(
+            self.settings.analyze_force_tr,
+            self.settings._mc_denoise_tr,
+            self.settings._stabilization_enabled,
+            self.settings.basic_tr,
+            self.repair_mask_enabled,
+            self.settings.source_match_tr
+            if self.settings.source_match_iterations > 1 and self.settings._source_match_enabled
+            else 0,
+            self.settings.sharpen_limit_radius
+            if self.settings.sharpen_limit_mode.is_temporal and self.settings._sharpness_limiting_enabled
+            else 0,
+            self.settings.final_tr,
+            bool(self.motion_blur_level),
         )
 
-    def apply_analyze(self) -> None:
-        if not self.required_analyze_tr:
-            return
+        self.mv.analyze(tr=tr, blksize=self.settings.analyze_blksize, overlap_div=self.settings.analyze_overlap)
 
         blksize = self.settings.analyze_blksize
-        if not self.settings.analyze_vectors:
-            preset = {**self.settings.analyze_preset, "search_clip": self.prefilter_output}
+        for _ in range(self.settings.analyze_refine):
+            blksize = refine_blksize(blksize)
+            self.mv.recalculate(
+                thsad=self.settings.analyze_thsad_recalc, blksize=blksize, overlap_div=self.settings.analyze_overlap
+            )
 
-        self.mv = MVTools(self.draft, vectors=self.settings.analyze_vectors, **preset)
+        return mv
 
-        if not self.settings.analyze_vectors:
-            self.mv.analyze(tr=self.required_analyze_tr, blksize=blksize, overlap_div=self.settings.analyze_overlap)
-
-            for _ in range(self.settings.analyze_refine):
-                blksize = refine_blksize(blksize)
-                self.mv.recalculate(
-                    thsad=self.settings.analyze_thsad_recalc,
-                    blksize=blksize,
-                    overlap_div=self.settings.analyze_overlap,
-                )
-
-    def apply_denoise(self) -> None:
-        self.denoise_output = self.clip
-
-        if not self.settings._denoise_enabled:
-            return
-
-        if self.settings.denoise_mc_denoise and self.settings.denoise_tr:
+    @cachedproperty
+    def run_denoiser(self) -> vs.VideoNode:
+        if self.settings._mc_denoise_tr:
             denoised = self.mv.compensate(
                 tr=self.settings.denoise_tr,
                 thscd=self.settings.analyze_thscd,
@@ -1042,48 +1187,50 @@ class _QTGMCRun:
         else:
             denoised = self.settings.denoise_func(self.draft, tr=self.settings.denoise_tr)
 
-        if self.is_deinterlace:
-            denoised = reinterlace(denoised, self.tff, self.apply_denoise)
+        if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
+            denoised = reinterlace(denoised, self.tff, self.__class__)
 
-        if self.settings.denoise_full_denoise:
-            self.denoise_output = denoised
+        return denoised
 
-        if not self.settings._noise_restore_enabled:
-            return
+    @cachedproperty
+    def denoise(self) -> vs.VideoNode:
+        return self.run_denoiser if self.settings.denoise_full_denoise else self.clip
 
-        self.noise = self.clip.std.MakeDiff(denoised)
+    @cachedproperty
+    def noise(self) -> vs.VideoNode:
+        noise = self.clip.std.MakeDiff(self.run_denoiser)
 
-        if self.is_deinterlace:
+        if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
             match self.settings.denoise_deint:
                 case self.settings.NoiseDeintMode.WEAVE:
-                    new_noise = self.noise.std.SeparateFields(self.tff.is_tff).std.DoubleWeave(self.tff.is_tff)
+                    noise = noise.std.SeparateFields(self.tff.is_tff).std.DoubleWeave(self.tff.is_tff)
                 case self.settings.NoiseDeintMode.BOB:
-                    new_noise = Catrom().bob(self.noise, tff=self.tff)
+                    noise = Catrom().bob(noise, tff=self.tff)
                 case self.settings.NoiseDeintMode.GENERATE:
-                    noise_source = self.noise.std.SeparateFields(self.tff.is_tff)
+                    noise = noise.std.SeparateFields(self.tff.is_tff)
 
-                    noise_max = Morpho.expand(noise_source, sw=2, sh=1, func=self.apply_denoise)
-                    noise_min = Morpho.inpand(noise_source, sw=2, sh=1, func=self.apply_denoise)
+                    noise_min = Morpho.inpand(noise, sw=2, sh=1, func=self.__class__)
+                    noise_max = Morpho.expand(noise, sw=2, sh=1, func=self.__class__)
 
-                    gen_noise = Grainer.GAUSS(
-                        noise_source,
+                    noise_gen = Grainer.GAUSS(
+                        noise,
                         ((0.5 * 255) / 3) ** 2,  # 3σ rule  # noqa: RUF003
                         protect_edges=False,
                         protect_neutral_chroma=False,
                         neutral_out=True,
                     )
-                    gen_noise = norm_expr(
-                        [noise_max, noise_min, gen_noise],
+                    noise_gen = norm_expr(
+                        [noise_max, noise_min, noise_gen],
                         "y x y - z neutral - range_size / 0.5 + * +",
-                        func=self.apply_denoise,
+                        func=self.__class__,
                     )
-                    new_noise = reweave(noise_source, gen_noise, self.tff.field, self.apply_denoise)
+                    noise = reweave(noise, noise_gen, self.tff.field, self.__class__)
 
-            self.noise = FieldBased.PROGRESSIVE.apply(new_noise)
+            noise = FieldBased.PROGRESSIVE.apply(noise)
 
         if self.settings._stabilization_enabled:
             noise_comp, _ = self.mv.compensate(
-                self.noise,
+                noise,
                 direction=MVDirection.BACKWARD,
                 tr=1,
                 thscd=self.settings.analyze_thscd,
@@ -1091,20 +1238,25 @@ class _QTGMCRun:
                 **self.settings.denoise_stabilize_comp_args,
             )
 
-            self.noise = norm_expr(
-                [self.noise, *noise_comp],
+            noise = norm_expr(
+                [noise, *noise_comp],
                 "x neutral - abs y neutral - abs > x y ? dup x y + 2 / swap - {weight} * +",
                 weight=self.settings.denoise_stabilize,
-                func=self.apply_denoise,
+                func=self.__class__,
             )
 
-    def apply_basic(self) -> None:
-        if self.is_repair:
-            self.bob_input = reinterlace(self.denoise_output, self.tff, self.apply_basic)
-        else:
-            self.bob_input = self.denoise_output
+        return noise
 
-        self.bobbed = self.interpolate(self.bob_input, self.settings.basic_bobber)
+    @cachedproperty
+    def bob_input(self) -> vs.VideoNode:
+        if self.mode is self.Mode.REPAIR:
+            return reinterlace(self.denoise, self.tff, self.__class__)
+
+        return self.denoise
+
+    @cachedproperty
+    def bobbed(self) -> vs.VideoNode:
+        bobbed = self.interpolate(self.bob_input, self.settings.basic_bobber)
 
         if self.repair_mask_enabled:
             mask = self.mv.mask(
@@ -1113,209 +1265,52 @@ class _QTGMCRun:
                 thscd=self.settings.analyze_thscd,
                 **self.settings.basic_mask_args,
             )
-            self.bobbed = self.denoise_output.std.MaskedMerge(self.bobbed, mask)
+            bobbed = self.denoise.std.MaskedMerge(bobbed, mask)
 
+        return bobbed
+
+    @cachedproperty
+    def basic(self) -> vs.VideoNode:
         smoothed = self.binomial_degrain(self.bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
 
         if self.settings.basic_tr:
-            smoothed = mask_shimmer(
-                smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.apply_basic
-            )
+            smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.__class__)
 
         if self.settings._source_match_enabled:
-            smoothed = self.apply_source_match(smoothed)
+            smoothed = self.source_match(smoothed)
 
         if self.settings.lossless_mode is self.settings.LosslessMode.PRESHARPEN:
-            smoothed = self.apply_lossless(smoothed)
+            smoothed = self.lossless(smoothed)
 
         if self.settings._sharpening_enabled:
-            resharp = self.apply_sharpen(smoothed)
+            resharp = self.sharpen(smoothed)
 
-            if self.settings._sharpness_limiting_enabled and self.settings.sharpen_limit_mode.is_presmooth:
+            if self.settings.sharpen_limit_mode.is_presmooth and self.settings._sharpness_limiting_enabled:
                 if self.settings.back_blend_mode in (
                     self.settings.BackBlendMode.PRELIMIT,
                     self.settings.BackBlendMode.BOTH,
                 ):
-                    resharp = self.apply_back_blend(resharp, smoothed)
+                    resharp = self.back_blend(resharp, smoothed)
 
-                resharp = self.apply_sharpen_limit(resharp)
+                resharp = self.sharpen_limit(resharp)
 
                 if self.settings.back_blend_mode in (
                     self.settings.BackBlendMode.POSTLIMIT,
                     self.settings.BackBlendMode.BOTH,
                 ):
-                    resharp = self.apply_back_blend(resharp, smoothed)
+                    resharp = self.back_blend(resharp, smoothed)
             elif self.settings.back_blend_mode is not self.settings.BackBlendMode.NONE:
-                resharp = self.apply_back_blend(resharp, smoothed)
+                resharp = self.back_blend(resharp, smoothed)
         else:
             resharp = smoothed
 
-        self.basic_output = self.apply_noise_restore(resharp, self.settings.basic_noise_restore)
+        return self.noise_restore(resharp, self.settings.basic_noise_restore)
 
-    def apply_source_match(self, clip: vs.VideoNode) -> vs.VideoNode:
-        def error_adjustment(ref: vs.VideoNode, clip: vs.VideoNode, tr: int) -> vs.VideoNode:
-            if not tr:
-                return ref
-
-            tr_f = 2 * tr - 1
-            tr_s = 2**tr_f
-            binomial_coeff = comb(tr_f, tr)
-            error_adj = tr_s / (binomial_coeff + self.settings.source_match_similarity * (tr_s - binomial_coeff))
-
-            return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=error_adjustment)
-
-        if self.tff.is_inter:
-            clip = reinterlace(clip, self.tff, self.apply_source_match)
-
-        adjusted = error_adjustment(self.bob_input, clip, self.settings.basic_tr)
-        new_bobbed = self.interpolate(adjusted, self.settings.basic_bobber)
-        matched = self.binomial_degrain(new_bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
-
-        if self.settings.source_match_iterations > 1:
-            if self.settings.source_match_enhance:
-                matched = unsharpen(
-                    matched,
-                    self.settings.source_match_enhance,
-                    BlurMatrix.BINOMIAL(),
-                    func=self.apply_source_match,
-                )
-
-            clip = reinterlace(matched, self.tff, self.apply_source_match) if self.tff.is_inter else matched
-
-            diff = self.bob_input.std.MakeDiff(clip)
-            refine_bobbed = self.interpolate(diff, self.settings.source_match_bobber)
-            refine_matched = self.binomial_degrain(
-                refine_bobbed, self.settings.source_match_tr, **self.settings.source_match_degrain_args
-            )
-
-            if self.settings.source_match_iterations > 2:
-                refine_adjusted = error_adjustment(refine_bobbed, refine_matched, self.settings.source_match_tr)
-                refine_matched = self.binomial_degrain(
-                    refine_adjusted, self.settings.source_match_tr, **self.settings.source_match_degrain_args
-                )
-
-            return matched.std.MergeDiff(refine_matched)
-
-        return matched
-
-    def apply_lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
-        if not self.tff.is_inter or clip is self.bobbed:
-            return clip
-
-        fields_src = self.denoise_output.std.SeparateFields(self.tff.is_tff)
-        if self.is_repair:
-            fields_src = fields_src.std.SelectEvery(4, (0, 3))
-        fields_flt = clip.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
-
-        woven = reweave(fields_src, fields_flt, self.tff.field, self.apply_lossless)
-
-        if self.settings.lossless_anti_comb:
-            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self.apply_lossless).std.MakeDiff(woven)
-            fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
-
-            cleaned_diff = norm_expr(
-                [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self.apply_lossless), fields_diff],
-                "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
-                func=self.apply_lossless,
-            )
-            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
-            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self.apply_lossless)
-
-        return FieldBased.PROGRESSIVE.apply(woven)
-
-    def apply_sharpen(self, clip: vs.VideoNode) -> vs.VideoNode:
-        resharp = clip
-
-        if self.settings.sharpen_strength:
-            if self.settings.sharpen_offset is not False:
-                dark_offset, bright_offset = self.settings.sharpen_offset
-
-                source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self.apply_sharpen)
-                source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self.apply_sharpen)
-
-                resharp = norm_expr(
-                    [clip, source_min, source_max],
-                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
-                    dark_offset=scale_delta(dark_offset, 8, self.clip),
-                    bright_offset=scale_delta(bright_offset, 8, self.clip),
-                    func=self.apply_sharpen,
-                )
-
-            resharp = unsharpen(
-                clip,
-                self.settings.sharpen_strength,
-                BlurMatrix.BINOMIAL()(resharp, func=self.apply_sharpen),
-                func=self.apply_sharpen,
-            )
-
-        if self.settings.sharpen_thin:
-            median_diff = norm_expr(
-                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self.apply_sharpen)],
-                "y x - {thin} * neutral +",
-                thin=self.settings.sharpen_thin,
-                func=self.apply_sharpen,
-            )
-            blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self.apply_sharpen)
-
-            resharp = norm_expr(
-                [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self.apply_sharpen), blurred_diff],
-                "y neutral - dup abs z neutral - abs > swap x + x ?",
-                func=self.apply_sharpen,
-            )
-
-        return resharp
-
-    def apply_back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
-        return flt.std.MergeDiff(gauss_blur(src.std.MakeDiff(flt), self.settings.back_blend_sigma))
-
-    def apply_sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
-        undershoot, overshoot = self.settings.sharpen_limit_clamp
-
-        if self.settings.sharpen_limit_mode.is_spatial:
-            if self.settings.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
-                clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
-            else:
-                inpand = Morpho.minimum(
-                    self.bobbed, iterations=self.settings.sharpen_limit_radius, func=self.apply_sharpen_limit
-                )
-                expand = Morpho.maximum(
-                    self.bobbed,
-                    iterations=self.settings.sharpen_limit_radius,
-                    func=self.apply_sharpen_limit,
-                )
-                clip = norm_expr(
-                    [clip, inpand, expand],
-                    "x y {undershoot} - z {overshoot} + clamp",
-                    undershoot=scale_delta(undershoot, 8, self.clip),
-                    overshoot=scale_delta(overshoot, 8, self.clip),
-                    func=self.apply_sharpen_limit,
-                )
-        elif self.settings.sharpen_limit_mode.is_temporal:
-            clip = mc_clamp(
-                clip,
-                self.bobbed,
-                self.mv,
-                (undershoot, overshoot),
-                self.apply_sharpen_limit,
-                tr=self.settings.sharpen_limit_radius,
-                thscd=self.settings.analyze_thscd,
-                **self.settings.sharpen_limit_comp_args,
-            )
-
-        return clip
-
-    def apply_noise_restore(self, clip: vs.VideoNode, restore: float) -> vs.VideoNode:
-        if restore:
-            clip = norm_expr(
-                [clip, self.noise], "x y neutral - {restore} * +", restore=restore, func=self.apply_noise_restore
-            )
-
-        return clip
-
-    def apply_final(self) -> None:
+    @cachedproperty
+    def final(self) -> vs.VideoNode:
         if self.settings.final_tr:
             smoothed = self.mv.degrain(
-                self.basic_output,
+                self.basic,
                 tr=self.settings.final_tr,
                 thsad=self.settings.final_thsad,
                 thsad2=self.settings.final_thsad2,
@@ -1323,25 +1318,24 @@ class _QTGMCRun:
                 **self.settings.final_degrain_args,
             )
         else:
-            smoothed = self.basic_output
+            smoothed = self.basic
 
         if smoothed is not self.bobbed:
-            smoothed = mask_shimmer(
-                smoothed, self.bobbed, **self.settings.final_mask_shimmer_args, func=self.apply_final
-            )
+            smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.final_mask_shimmer_args, func=self.__class__)
 
-        if self.settings._sharpness_limiting_enabled and self.settings.sharpen_limit_mode.is_postsmooth:
-            smoothed = self.apply_sharpen_limit(smoothed)
+        if self.settings.sharpen_limit_mode.is_postsmooth and self.settings._sharpness_limiting_enabled:
+            smoothed = self.sharpen_limit(smoothed)
 
         if self.settings.lossless_mode is self.settings.LosslessMode.POSTSMOOTH:
-            smoothed = self.apply_lossless(smoothed)
+            smoothed = self.lossless(smoothed)
 
-        self.final_output = self.apply_noise_restore(smoothed, self.settings.final_noise_restore)
+        return self.noise_restore(smoothed, self.settings.final_noise_restore)
 
-    def apply_motion_blur(self) -> None:
+    @cachedproperty
+    def motion_blur(self) -> vs.VideoNode:
         if self.motion_blur_level:
             blurred = self.mv.flow_blur(
-                self.final_output,
+                self.final,
                 blur=self.motion_blur_level,
                 thscd=self.settings.analyze_thscd,
                 **self.settings.motion_blur_blur_args,
@@ -1355,37 +1349,27 @@ class _QTGMCRun:
                     **self.settings.motion_blur_mask_args,
                 )
 
-                blurred = self.final_output.std.MaskedMerge(blurred, mask)
+                blurred = self.final.std.MaskedMerge(blurred, mask)
         else:
-            blurred = self.final_output
+            blurred = self.final
 
         if self.motion_blur_fps_divisor > 1:
             blurred = blurred[:: self.motion_blur_fps_divisor]
 
-        self.motion_blur_output = blurred
-
-    def run(self) -> vs.VideoNode:
-        self.apply_prefilter()
-        self.apply_analyze()
-        self.apply_denoise()
-        self.apply_basic()
-        self.apply_final()
-        self.apply_motion_blur()
-
-        return self.motion_blur_output
+        return blurred
 
 
-class QTempGaussMC(_QTGMCBuilder, VSObject):
+class QTempGaussMC(_QTGMCBuilder):
     """
     Quick Temporal Gaussian Motion Compensated (QTGMC)
 
-    A very high-quality deinterlacer with a range of features for both quality and convenience. These include extensive
-    noise processing capabilities, support for repair of progressive material, precision source matching, shutter speed
+    A very high-quality deinterlacer with a range of features for quality and convenience. This includes extensive noise
+    processing capabilities, support for repair of progressive material, precision source matching, shutter speed
     simulation, and more.
 
     Originally based on TempGaussMC by Didée.
 
-    Basic usage: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Usage Info: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     def deinterlace(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
@@ -1402,7 +1386,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Deinterlaced clip.
         """
-        return _QTGMCRun(clip, tff, _QTGMCRun.Mode.DEINTERLACE, self, self.deinterlace).run()
+        return _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace).motion_blur
 
     def bob(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
@@ -1418,7 +1402,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Bobbed clip.
         """
-        return _QTGMCRun(clip, tff, _QTGMCRun.Mode.BOB, self, self.bob).run()
+        return _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.BOB, self, self.bob).motion_blur
 
     def repair(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
@@ -1433,7 +1417,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Repaired clip.
         """
-        return _QTGMCRun(clip, tff, _QTGMCRun.Mode.REPAIR, self, self.repair).run()
+        return _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.REPAIR, self, self.repair).motion_blur
 
     def deshimmer(self, clip: vs.VideoNode) -> vs.VideoNode:
         """
@@ -1447,7 +1431,7 @@ class QTempGaussMC(_QTGMCBuilder, VSObject):
         Returns:
             Deshimmered clip.
         """
-        return _QTGMCRun(clip, FieldBased.PROGRESSIVE, _QTGMCRun.Mode.DESHIMMER, self, self.deshimmer).run()
+        return _QTGMCGraph(clip, FieldBased.PROGRESSIVE, _QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer).motion_blur
 
 
 def mask_shimmer(
@@ -1465,16 +1449,14 @@ def mask_shimmer(
         - Vertical morphological analysis: Extracts the difference between source and filtered clips, running
             vertical opening and closing operations to collapse thin bob shimmer while leaving large motion
             artifacts intact.
-        - Safety margin adjustment: Applies extra dilation passes to fine-tune detection boundaries on soft sources,
-            ensuring proper mask coverage on blurry edges.
 
     Args:
         flt: Filtered clip to perform masking on.
         src: Source clip to restore from.
         erosion_distance: Vertical radius for shimmer detection. Larger values capture more spread-out artifacts on soft
             sources. Defaults to 4.
-        over_dilation: Extra dilation passes for safety margins. Larger values shrink the mask boundary to avoid
-            artifacts on blurry edges. Defaults to 0.
+        over_dilation: Extra dilation passes to restore beyond the detected lines. Larger values restore more beyond the
+            mask boundary. Defaults to 0.
         func: Function returned for custom error handling. This should only be set by VS package developers. Defaults to
             None.
 
@@ -1486,29 +1468,29 @@ def mask_shimmer(
     if not erosion_distance:
         return flt
 
-    ed_pos = 1 + erosion_distance // 3
-    ed_neg = (erosion_distance + 4) // 3
+    ed1 = 1 + erosion_distance // 3
+    ed2 = (erosion_distance + 4) // 3
     ed_res = erosion_distance % 3
-    od_pos, od_neg = divmod(over_dilation, 3)
+    od, od_res = divmod(over_dilation, 3)
 
     ops = ((Morpho.maximum, Morpho.inflate), (Morpho.minimum, Morpho.deflate))
 
     diff = src.std.MakeDiff(flt)
 
     processed = list[vs.VideoNode]()
-    for (grow_op, inflate_op), (shrink_op, deflate_op) in (ops, ops[::-1]):
-        clip = grow_op(diff, iterations=ed_pos, coords=Coordinates.VERTICAL, func=func)
+    for (expand_op, inflate_op), (inpand_op, deflate_op) in (ops, ops[::-1]):
+        clip = expand_op(diff, iterations=ed1, coords=Coordinates.VERTICAL, func=func)
 
         if ed_res:
             clip = inflate_op(clip, func=func)
         if ed_res == 2:
             clip = median_blur(clip, func=func)
 
-        clip = shrink_op(clip, iterations=ed_neg, coords=Coordinates.VERTICAL, func=func)
+        clip = inpand_op(clip, iterations=ed2, coords=Coordinates.VERTICAL, func=func)
 
         if over_dilation:
-            clip = shrink_op(clip, iterations=od_pos, func=func)
-            clip = deflate_op(clip, iterations=od_neg, func=func)
+            clip = inpand_op(clip, iterations=od, func=func)
+            clip = deflate_op(clip, iterations=od_res, func=func)
 
         processed.append(clip)
 

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1139,17 +1139,13 @@ class QTGMCGraph(VSObject):
             )
 
         if self.settings.sharpen_thin:
-            median_diff = norm_expr(
-                [clip, median_blur(clip, mode=ConvMode.VERTICAL, func=self._sharpen)],
-                "y x - {thin} * neutral +",
-                thin=self.settings.sharpen_thin,
-                func=self._sharpen,
-            )
+            median_diff = median_blur(clip, mode=ConvMode.VERTICAL, func=self._sharpen).std.MakeDiff(clip)
             blurred_diff = BlurMatrix.BINOMIAL(mode=ConvMode.HORIZONTAL)(median_diff, func=self._sharpen)
 
             resharp = norm_expr(
                 [resharp, BlurMatrix.BINOMIAL()(blurred_diff, func=self._sharpen), blurred_diff],
-                "y neutral - dup abs z neutral - abs > swap x + x ?",
+                "y neutral - dup abs z neutral - abs > swap {thin} * x + x ?",
+                thin=self.settings.sharpen_thin,
                 func=self._sharpen,
             )
 

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from copy import deepcopy
 from enum import auto
@@ -914,7 +916,7 @@ class _QTGMCBuilder:
 
 class QTGMCGraph(VSObject):
     """
-    Processing graph for a single [QTempGaussMC][vsdeinterlace.QTempGaussMC] operation.
+    Processing graph for an individual [QTempGaussMC][vsdeinterlace.QTempGaussMC] run.
 
     The graph exposes each processing stage as a lazily evaluated cached property. It is returned alongside the output
     clip when `return_graph=True` is passed to a [QTempGaussMC][vsdeinterlace.QTempGaussMC] processing method. This
@@ -956,6 +958,15 @@ class QTGMCGraph(VSObject):
         Removes horizontal shimmering artifacts from progressive sources.
         """
 
+        def __call__(
+            self,
+            clip: vs.VideoNode,
+            tff: FieldBasedLike | bool | None,
+            settings: _QTGMCBuilder,
+            func: FuncExcept,
+        ) -> QTGMCGraph:
+            return QTGMCGraph(self, clip, tff, settings, func)
+
     class _FrozenCache(dict[str, Any]):
         def __contains__(self, key: object) -> bool:
             if super().__contains__(key):
@@ -965,17 +976,17 @@ class QTGMCGraph(VSObject):
 
     def __init__(
         self,
+        mode: Mode,
         clip: vs.VideoNode,
         tff: FieldBasedLike | bool | None,
-        mode: Mode,
         settings: _QTGMCBuilder,
         func: FuncExcept,
     ) -> None:
         """
         Args:
+            mode: Processing mode used to construct the graph.
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip.
-            mode: Processing mode used to construct the graph.
             settings: `_QTGMCBuilder` instance containing the settings for each processing stage.
             func: Function returned for custom error handling. This should only be set by VS package developers.
 
@@ -1573,7 +1584,7 @@ class QTempGaussMC(_QTGMCBuilder):
             object if `return_graph` is `True`.
         """
 
-        run = QTGMCGraph(clip, tff, QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace)
+        run = QTGMCGraph.Mode.DEINTERLACE(clip, tff, self, self.deinterlace)
 
         if return_graph:
             return run.motion_blur, run.freeze()
@@ -1621,7 +1632,7 @@ class QTempGaussMC(_QTGMCBuilder):
             `return_graph` is `True`.
         """
 
-        run = QTGMCGraph(clip, tff, QTGMCGraph.Mode.BOB, self, self.bob)
+        run = QTGMCGraph.Mode.BOB(clip, tff, self, self.bob)
 
         if return_graph:
             return run.motion_blur, run.freeze()
@@ -1668,7 +1679,7 @@ class QTempGaussMC(_QTGMCBuilder):
             `return_graph` is `True`.
         """
 
-        run = QTGMCGraph(clip, tff, QTGMCGraph.Mode.REPAIR, self, self.repair)
+        run = QTGMCGraph.Mode.REPAIR(clip, tff, self, self.repair)
 
         if return_graph:
             return run.motion_blur, run.freeze()
@@ -1705,7 +1716,7 @@ class QTempGaussMC(_QTGMCBuilder):
                 object if `return_graph` is `True`.
         """
 
-        run = QTGMCGraph(clip, FieldBased.PROGRESSIVE, QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer)
+        run = QTGMCGraph.Mode.DESHIMMER(clip, FieldBased.PROGRESSIVE, self, self.deshimmer)
 
         if return_graph:
             return run.motion_blur, run.freeze()

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -219,18 +219,22 @@ class _QTGMCBuilder:
 
         @cachedproperty
         def is_spatial(self) -> bool:
+            """Whether the mode uses spatial sharpness limiting."""
             return self in (self.SPATIAL_PRESMOOTH, self.SPATIAL_POSTSMOOTH)
 
         @cachedproperty
         def is_temporal(self) -> bool:
+            """Whether the mode uses temporal sharpness limiting."""
             return self in (self.TEMPORAL_PRESMOOTH, self.TEMPORAL_POSTSMOOTH)
 
         @cachedproperty
         def is_presmooth(self) -> bool:
+            """Whether the mode applies sharpness limiting prior to smoothing."""
             return self in (self.SPATIAL_PRESMOOTH, self.TEMPORAL_PRESMOOTH)
 
         @cachedproperty
         def is_postsmooth(self) -> bool:
+            """Whether the mode applies sharpness limiting after smoothing."""
             return self in (self.SPATIAL_POSTSMOOTH, self.TEMPORAL_POSTSMOOTH)
 
     @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
@@ -1576,7 +1580,7 @@ class QTempGaussMC(_QTGMCBuilder):
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
             return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
-                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                inspecting the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
                 motion-compensated processing. Defaults to False.
 
         Returns:
@@ -1624,7 +1628,7 @@ class QTempGaussMC(_QTGMCBuilder):
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
             return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
-                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                inspecting the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
                 motion-compensated processing. Defaults to False.
 
         Returns:
@@ -1671,7 +1675,7 @@ class QTempGaussMC(_QTGMCBuilder):
             clip: Clip to process.
             tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
             return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
-                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                inspecting the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
                 motion-compensated processing. Defaults to False.
 
         Returns:
@@ -1708,7 +1712,7 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             return_graph: Whether to return the [QTGMCGraph][vsdeinterlace.qtgmc.QTGMCGraph] object. It can be used for
-                debugging the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
+                inspecting the output or [QTGMCGraph.mv][vsdeinterlace.qtgmc.QTGMCGraph.mv] can be reused for other
                 motion-compensated processing. Defaults to False.
 
         Returns:

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1135,7 +1135,7 @@ class _QTGMCGraph(VSObject):
 
     @cachedproperty
     def repair_mask_enabled(self) -> bool:
-        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml"))
+        return bool(self.mode is self.Mode.REPAIR and self.settings.basic_mask_args.get("ml") != 0)
 
     @cachedproperty
     def motion_blur_level(self) -> float:
@@ -1395,7 +1395,7 @@ class _QTGMCGraph(VSObject):
                 **self.settings.motion_blur_blur_args,
             )
 
-            if self.settings.motion_blur_mask_args.get("ml"):
+            if self.settings.motion_blur_mask_args.get("ml") != 0:
                 mask = self.mv.mask(
                     direction=MVDirection.BACKWARD,
                     kind=MaskMode.VECTOR_LENGTH,
@@ -1457,12 +1457,12 @@ class QTempGaussMC(_QTGMCBuilder):
 
         Args:
             clip: Clip to process.
-            tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
+            tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
             debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
             The deinterlaced clip, or a tuple of (clip, graph) containing the deinterlaced clip and the internal
-            `_QTGMCGraph` object if debug is True
+            `_QTGMCGraph` object if debug is `True`
         """
 
         run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace)
@@ -1503,12 +1503,12 @@ class QTempGaussMC(_QTGMCBuilder):
 
         Args:
             clip: Clip to process.
-            tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
+            tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
             debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
             The bobbed clip, or a tuple of (clip, graph) containing the bobbed clip and the internal `_QTGMCGraph`
-            object if debug is True
+            object if debug is `True`
         """
 
         run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.BOB, self, self.bob)
@@ -1548,12 +1548,12 @@ class QTempGaussMC(_QTGMCBuilder):
 
         Args:
             clip: Clip to process.
-            tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
+            tff: Field order (top-field-first). If `None`, inferred from the clip. Defaults to None.
             debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
             The repaired clip, or a tuple of (clip, graph) containing the repaired clip and the internal `_QTGMCGraph`
-            object if debug is True
+            object if debug is `True`
         """
 
         run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.REPAIR, self, self.repair)
@@ -1584,7 +1584,7 @@ class QTempGaussMC(_QTGMCBuilder):
 
         Returns:
             The deshimmered clip, or a tuple of (clip, graph) containing the deshimmered clip and the internal
-            `_QTGMCGraph` object if debug is True
+            `_QTGMCGraph` object if debug is `True`
         """
 
         run = _QTGMCGraph(clip, FieldBased.PROGRESSIVE, _QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer)

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -712,9 +712,9 @@ class _QTGMCBuilder:
         Args:
             strength: Sharpening strength. Higher values result in more sharpening. Defaults to 1 when
                 [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0, and 0 otherwise.
-            offset: Offsets the blur source to the vertical min/max average ± this value (8-bit). Smaller values result
-                in more vertical sharpening. Passing a tuple of values results in asymmetric offsetting. `False`
-                disables range limiting. Defaults to 1.
+            offset: Shifts the unsharpen blur source to the vertical min/max average ± this value (8-bit). Smaller
+                values result in more vertical sharpening. Passing a tuple of values results in asymmetric offsetting.
+                `False` disables range limiting. Defaults to 1.
             thin: How much to thin down horizontal edges. Higher values result in more thinning. Defaults to 0.
         """
 
@@ -1363,12 +1363,12 @@ class QTGMCGraph(VSObject):
 
                     noise_gen = Grainer.GAUSS(
                         noise,
-                        ((0.5 * 255) / 3) ** 2,  # 3σ rule  # noqa: RUF003
+                        ((0.5 * 255) / 3) ** 2,  # 3σ rule.  # noqa: RUF003
                         protect_edges=False,
                         protect_neutral_chroma=False,
                         neutral_out=True,
                     )
-                    noise_gen = norm_expr(
+                    noise_gen = norm_expr(  # Off-center neutral in int formats prevents the scale from reaching 1.
                         [noise_max, noise_min, noise_gen],
                         "y x y - z neutral - range_size / 0.5 + * +",
                         func=self.func,
@@ -1536,7 +1536,7 @@ class QTempGaussMC(_QTGMCBuilder):
     processing capabilities, support for repair of progressive material, precision source matching, shutter speed
     simulation, and more.
 
-    Originally based on QTGMC by Vit and TempGaussMC by Didée
+    Originally based on QTGMC by Vit and TempGaussMC by Didée.
 
     Usage examples:
         - Basic call with defaults:

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -92,7 +92,7 @@ class QTGMCArgs:
 
 class _QTGMCBuilder:
     class NoiseDeintMode(CustomIntEnum):
-        """How to 'deinterlace' noise taken from an interlaced source before restoration."""
+        """How to 'deinterlace' noise taken from an interlaced source."""
 
         WEAVE = auto()
         """
@@ -470,8 +470,7 @@ class _QTGMCBuilder:
             func: Denoising function to use. Defaults to DFTTest(sigma=8).
             tr: Temporal radius of the denoising function and its motion compensation. Larger values remove/separate
                 more noise. Defaults to 1.
-            deint: How to 'deinterlace' noise taken from an interlaced source before restoration. Defaults to
-                NoiseDeintMode.GENERATE.
+            deint: How to 'deinterlace' noise taken from an interlaced source. Defaults to NoiseDeintMode.GENERATE.
             mc_denoise: Whether to motion-compensate the denoiser being used. Provides more accurate denoising/noise
                 extraction when using a non-motion-compensated temporal denoiser. Defaults to True.
             full_denoise: Whether the denoised output will be directly used in all subsequent processing. If `False`,

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -1,8 +1,9 @@
-# ruff: noqa B006
-import math
+# ruff: noqa: B006, B008, RUF003
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager, suppress
 from copy import deepcopy
+from enum import auto
+from math import comb
 from typing import Any, Literal, Protocol, Self, TypedDict
 
 from jetpytools import CustomIntEnum, CustomValueError, FuncExcept, fallback, normalize_seq
@@ -19,7 +20,8 @@ from vsdenoise import (
     prefilter_to_full_range,
     refine_blksize,
 )
-from vsexprtools import ExprOp, norm_expr
+from vsexprtools import norm_expr
+from vsjetpack import deprecated
 from vskernels import Bobber, BobberLike, Catrom
 from vsmasktools import Coordinates, Morpho
 from vsrgtools import BlurMatrix, gauss_blur, median_blur, remove_grain, repair, unsharpen
@@ -49,51 +51,63 @@ class QTGMCArgs:
     """Namespace containing helper TypedDict definitions for various argument groups."""
 
     class PrefilterToFullRange(TypedDict, total=False):
-        """
-        Arguments available when passing to [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range].
-        """
+        """Arguments accepted by [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range]."""
 
         slope: float
         smooth: float
 
     class MaskShimmer(TypedDict, total=False):
         """
-        Arguments available when passing to the internal `_mask_shimmer` method through
+        Arguments accepted by the internal `_mask_shimmer` method through
         [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter],
-        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]
-        and [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
+        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
+        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
+
+        Removes areas of difference between a temporally blurred clip and a reference clip that are not due to
+        bob shimmer by only allowing thin horizontal areas of difference.
+
+        High-level overview:
+            - Vertical morphological analysis: Extracts the difference between source and filtered clips, running
+                vertical opening and closing operations to collapse thin bob shimmer while leaving large motion
+                artifacts intact.
+            - Safety margin adjustment: Applies extra dilation passes to fine-tune detection boundaries on soft sources,
+                ensuring proper mask coverage on blurry edges.
         """
 
         erosion_distance: int
-        """How much to deflate then reflate to remove thin areas."""
+        """
+        Vertical radius for shimmer detection.
+
+        Larger values capture more spread-out shimmer artifacts on soft sources.
+        """
+
         over_dilation: int
-        """Extra inflation to ensure areas to restore back are fully caught."""
+        """
+        Extra dilation passes for safety margins.
+
+        Larger values shrink the mask boundary to prevent artifacts on blurry edges. Defaults to 0.
+        """
 
     class Compensate(TypedDict, total=False):
-        """
-        Arguments available when passing to [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate].
-        """
+        """Arguments accepted by [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate]."""
 
         thsad: int | None
         time: float | None
 
     class Degrain(TypedDict, total=False):
         """
-        Arguments available when passing to the internal `binomial_degrain` method,
-        calling [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain] through
-        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]
-        and [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match]
-        or directly calling [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain] through
-        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final]
+        Arguments accepted by the internal `_binomial_degrain` method, calling
+        [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain] through
+        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
+        [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match], or directly through
+        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
         """
 
         limit: float | tuple[float, float] | None
         planes: Planes
 
     class Mask(TypedDict, total=False):
-        """
-        Arguments available when passing to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask].
-        """
+        """Arguments accepted by [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]."""
 
         delta: int
         ml: float | None
@@ -102,9 +116,7 @@ class QTGMCArgs:
         scval: float | None
 
     class Blur(TypedDict, total=False):
-        """
-        Arguments available when passing to [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur].
-        """
+        """Arguments accepted by [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur]."""
 
         prec: int | None
 
@@ -113,237 +125,205 @@ class QTempGaussMC(VSObject):
     """
     Quick Temporal Gaussian Motion Compensated (QTGMC)
 
-    A very high quality deinterlacer with a range of features for both quality and convenience.
-    These include extensive noise processing capabilities, support for repair of progressive material,
-    precision source matching, shutter speed simulation, etc.
+    A very high-quality deinterlacer with a range of features for both quality and convenience. These include extensive
+    noise processing capabilities, support for repair of progressive material, precision source matching, shutter speed
+    simulation, and more.
 
     Originally based on TempGaussMC by Didée.
 
-    Basic usage:
-        ```py
-        deinterlace = QTempGaussMC().deinterlace(clip)
-        ```
+    Basic usage: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
 
-    Refer to the [AviSynth QTGMC documentation](http://avisynth.nl/index.php/QTGMC)
-    and the [havsfunc implementation](https://github.com/HomeOfVapourSynthEvolution/havsfunc/blob/aa79ebc9eb5517a3a76a74caa98a9d41993ac39b/havsfunc/havsfunc.py#L598-L848)
-    for detailed explanations of the underlying algorithm.
-
-    These resources remain relevant, as the core algorithm used here is largely similar.
-
-    Note that parameter names differ in this implementation due to a complete rewrite.
-    A mapping between vsjetpack and havsfunc parameters is available [here](https://gist.github.com/Ichunjo/76c96f1130c9e9f972de956f40571e54).
-
-    Examples:
-        - ...
-        - Passing a badly deinterlaced input to reduce shimmering (equivalent to `InputType=2, ProgSADMask=12`):
-        ```python
-        clip = QTempGaussMC().basic(mask_args={"ml": 12}).repair(clip)
-        ```
-        Or:
-        ```python
-        clip = QTempGaussMC(basic_mask_args={"ml": 12}).repair(clip)
-        ```
+    Alternate documentation reference: [AviSynth documentation](http://avisynth.nl/index.php/QTGMC)
     """
 
     mv: MVTools
-    """MVTools instance used during processing."""
+    """[MVTools][vsdenoise.mvtools.mvtools.MVTools] instance used during processing."""
 
     clip: vs.VideoNode
     """Clip to process."""
 
     draft: vs.VideoNode
-    """Draft processed clip, used as a base for prefiltering & denoising."""
+    """
+    Draft processed clip, used as a base for [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter] and
+    [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise].
+    """
 
     input: vs.VideoNode
-    """Prepared input clip for high quality interpolation."""
+    """
+    Prepared input clip for high-quality interpolation. Used as a base for the internal `_interpolate` method.
+    """
 
     bobbed: vs.VideoNode
-    """High quality bobbed clip, initial spatial interpolation."""
+    """
+    High-quality bobbed clip, acting as a spatial interpolation base for
+    [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
+    [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match].
+    """
 
     noise: vs.VideoNode
-    """Extracted noise when noise processing is enabled."""
+    """Noise extracted by [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
 
     prefilter_output: vs.VideoNode
-    """Output of the prefilter stage."""
+    """Output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter]."""
 
     denoise_output: vs.VideoNode
-    """Output of the denoise stage."""
+    """Output of [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise]."""
 
     basic_output: vs.VideoNode
-    """Output of the basic stage."""
+    """Output of [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic]."""
 
     final_output: vs.VideoNode
-    """Output of the final stage."""
+    """Output of [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final]."""
 
     motion_blur_output: vs.VideoNode
-    """Output of the motion blur stage."""
+    """Output of [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur]."""
 
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
     class SearchPostProcess(CustomIntEnum):
-        """
-        Prefiltering to apply in order to assist with motion search.
-        """
-
         GAUSSBLUR = 0
-        """
-        Gaussian blur.
-        """
-
         GAUSSBLUR_EDGESOFTEN = 1
-        """
-        Gaussian blur & limited edge softening.
-        """
 
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
     class NoiseProcessMode(CustomIntEnum):
-        """
-        How to handle processing noise in the source.
-        """
-
         IDENTIFY = 0
-        """
-        Identify noise only & optionally restore some noise back at the end of basic or final stages.
-        """
-
         DENOISE = 1
-        """
-        Denoise source & optionally restore some noise back at the end of basic or final stages.
-        """
+
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
+    class SharpenMode(CustomIntEnum):
+        UNSHARP = 0
+        UNSHARP_MINMAX = 1
+
+    @deprecated("This enum is deprecated and will be removed in a future version.", category=DeprecationWarning)
+    class SourceMatchMode(CustomIntEnum):
+        NONE = 0
+        BASIC = 1
+        REFINED = 2
+        TWICE_REFINED = 3
 
     class NoiseDeintMode(CustomIntEnum):
+        WEAVE = auto()
         """
-        When noise is taken from interlaced source, how to 'deinterlace' it before restoring.
+        Double weave source noise.
+
+        Lags behind by one frame.
         """
 
-        WEAVE = 0
+        BOB = auto()
         """
-        Double weave source noise, lags behind by one frame.
+        Bob source noise.
+
+        Results in coarse noise.
         """
 
-        BOB = 1
+        GENERATE = auto()
         """
-        Bob source noise, results in coarse noise.
-        """
-
-        GENERATE = 2
-        """
-        Generates fresh noise lines.
-        """
-
-    class SharpenMode(CustomIntEnum):
-        """
-        How to re-sharpen the clip after temporal smoothing.
-        """
-
-        UNSHARP = 0
-        """
-        Re-sharpening using unsharpening.
-        """
-
-        UNSHARP_MINMAX = 1
-        """
-        Re-sharpening using unsharpening clamped to the local 3x3 min/max average.
+        Generate fresh noise lines.
         """
 
     class SharpenLimitMode(CustomIntEnum):
+        NONE = auto()
         """
-        How to limit and when to apply re-sharpening of the clip.
-        """
-
-        SPATIAL_PRESMOOTH = 0
-        """
-        Spatial sharpness limiting prior to final stage.
+        No sharpness limiting.
         """
 
-        TEMPORAL_PRESMOOTH = 1
+        SPATIAL_PRESMOOTH = auto()
         """
-        Temporal sharpness limiting prior to final stage.
+        Spatial sharpness limiting prior to [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
+
+        Spatial limiting is less accurate, but allows more sharpening. Applying sharpness limiting earlier in the
+        algorithm leaves the result softer, but produces fewer artifacts.
         """
 
-        SPATIAL_POSTSMOOTH = 2
+        TEMPORAL_PRESMOOTH = auto()
         """
-        Spatial sharpness limiting after the final stage.
+        Temporal sharpness limiting prior to [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
+
+        Temporal limiting is more accurate, but allows less sharpening. Applying sharpness limiting earlier in the
+        algorithm leaves the result softer, but produces fewer artifacts.
         """
 
-        TEMPORAL_POSTSMOOTH = 3
+        SPATIAL_POSTSMOOTH = auto()
         """
-        Temporal sharpness limiting after the final stage.
+        Spatial sharpness limiting after [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
+
+        Spatial limiting is less accurate, but allows more sharpening. Applying sharpness limiting later in the
+        algorithm leaves the result sharper, but can produce additional artifacts.
+        """
+
+        TEMPORAL_POSTSMOOTH = auto()
+        """
+        Temporal sharpness limiting after [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
+
+        Temporal limiting is more accurate, but allows less sharpening. Applying sharpness limiting later in the
+        algorithm leaves the result sharper, but can produce additional artifacts.
         """
 
     class BackBlendMode(CustomIntEnum):
+        NONE = auto()
         """
-        When to back blend (blurred) difference between pre & post sharpened clip.
+        No back-blending.
+
+        Keeps all [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen] frequencies.
         """
 
-        PRELIMIT = 0
+        PRELIMIT = auto()
         """
-        Perform back-blending prior to sharpness limiting.
+        Back-blending prior to [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
+
+        Provides the weakest low-frequency dampening.
         """
 
-        POSTLIMIT = 1
+        POSTLIMIT = auto()
         """
-        Perform back-blending after sharpness limiting.
+        Back-blending after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
+
+        Provides the strongest low-frequency dampening.
+
+        Note:
+            Identical to `PRELIMIT` when using `SharpenLimitMode.NONE`, `SharpenLimitMode.SPATIAL_POSTSMOOTH` or
+            `SharpenLimitMode.TEMPORAL_POSTSMOOTH`.
         """
 
-        BOTH = 2
+        BOTH = auto()
         """
-        Perform back-blending both before and after sharpness limiting.
-        """
+        Back-blending both before and after [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit].
 
-    class SourceMatchMode(CustomIntEnum):
-        """
-        Creates higher fidelity output with extra processing.
-        Will capture more source detail and reduce oversharpening / haloing.
-        """
+        Provides a balanced middle ground between `PRELIMIT` sharpening strength and `POSTLIMIT` dampening.
 
-        NONE = 0
-        """
-        No source match processing.
-        """
-
-        BASIC = 1
-        """
-        Conservative halfway stage that rarely introduces artifacts.
-        """
-
-        REFINED = 2
-        """
-        Restores almost exact source detail but is sensitive to noise & can introduce occasional aliasing.
-        """
-
-        TWICE_REFINED = 3
-        """
-        Restores almost exact source detail.
+        Note:
+            Identical to `PRELIMIT` when using `SharpenLimitMode.NONE`, `SharpenLimitMode.SPATIAL_POSTSMOOTH` or
+            `SharpenLimitMode.TEMPORAL_POSTSMOOTH`.
         """
 
     class LosslessMode(CustomIntEnum):
+        NONE = auto()
         """
-        When to put exact source fields into result & clean any artifacts.
-        """
-
-        NONE = 0
-        """
-        Do not restore source fields.
+        Do not restore the original fields.
         """
 
-        PRESHARPEN = 1
+        PRESHARPEN = auto()
         """
-        Restore source fields prior to re-sharpening. Not exactly lossless.
+        Restore the original fields prior to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen].
+
+        Provides near-lossless fidelity, mitigates most artifacts, and retains sharpness control.
         """
 
-        POSTSMOOTH = 2
+        POSTSMOOTH = auto()
         """
-        Restore source fields after final temporal smooth. True lossless but less stable.
+        Restore the original fields after [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] smoothing.
+
+        Provides true lossless output, given [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] `noise_restore` is
+        not used. Offers minimal sharpness control and tends to have more significant artifacts.
         """
 
     def __init__(self, **kwargs: Any) -> None:
         """
         Args:
-            **kwargs: Additional arguments to be passed to the parameter stage methods.
-                Use the method's name as prefix to pass an argument to the respective method.
-
-                Example for passing tr=1 to the prefilter stage: `prefilter_tr=1`.
+            **kwargs: Additional arguments to be passed to the parameter category methods. Use the method's name as a
+                prefix to pass an argument to the respective method.
         """
 
-        # Set default parameters for all the stages in this exact order
+        # Set default parameters for all the categories in this exact order
         self._settings_methods = (
             self.prefilter,
             self.analyze,
@@ -371,33 +351,70 @@ class QTempGaussMC(VSObject):
         *,
         tr: int = 2,
         sc_threshold: float = 0.1,
-        postprocess: SearchPostProcess = SearchPostProcess.GAUSSBLUR_EDGESOFTEN,
-        strength: tuple[float, float] | Literal[False] = (1.9, 0.1),
+        postprocess: SearchPostProcess | None = None,
+        strength: tuple[float, float] = (1.9, 0.9),
         limit: tuple[float, float, float] = (3, 7, 2),
         bias: float = 0.51,
         range_expansion_args: QTGMCArgs.PrefilterToFullRange | None = None,
         mask_shimmer_args: QTGMCArgs.MaskShimmer | None = {"erosion_distance": 4},
     ) -> Self:
         """
-        Configure parameters for the prefilter stage.
+        Configures parameters for the prefilter stage.
+
+        Prepares a suitable search clip to be provided for motion analysis purposes.
+
+        High-level overview:
+            - [[QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]] Draft bobbed clip generation:
+                Begins with simple spatial interpolation to produce
+                [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft], which inherently contains severe temporal
+                instability known as bob shimmer.
+            - [[QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]] Vertical spatial pre-filtering: Applies a
+                vertical binomial blur to filter out residual vertical artifacts.
+            - Temporal binomial blurring: Applies a temporal binomial blur to smooth
+                [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft], removing the shimmer, which prevents
+                [MVTools][vsdenoise.mvtools.mvtools.MVTools] from falsely latching onto the shimmer as motion (though
+                this uncompensated blur introduces ghosting).
+            - Shimmer masking: Uses a specialized masking process to eliminate the introduced ghosting while retaining
+                the shimmer removal.
+            - Gaussian blurring post-processing: Applies Gaussian blurring to lower high SAD values caused by sharp
+                edges, ensuring edges are properly processed rather than skipped.
+            - Edge detail restoration: Conservatively restores essential edge detail from
+                [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft] back into the blurred clip via a limiting process
+                so [MVTools][vsdenoise.mvtools.mvtools.MVTools] retains the ability to track motion effectively.
+            - Levels optimization:
+                Applies level adjustments to brighten dark regions and enhance contrast, enabling
+                [MVTools][vsdenoise.mvtools.mvtools.MVTools] to better track dark details, reducing downstream ghosting
+                and blurring.
 
         Args:
-            tr: Radius of the initial temporal binomial smooth.
-            sc_threshold: Threshold for scene changes, disables sc detection if False.
-            postprocess: Post-processing routine to use.
-            strength: Tuple containing gaussian blur sigma & blend weight of the blur.
-            limit: 3-step limiting (8-bit) thresholds for the gaussian blur post-processing. Only for
-                [SearchPostProcess.GAUSSBLUR_EDGESOFTEN][vsdeinterlace.qtgmc.QTempGaussMC.SearchPostProcess.GAUSSBLUR_EDGESOFTEN].
-            bias: Bias for blending the gaussian blurred clip with the limited output. Only for
-                [SearchPostProcess.GAUSSBLUR_EDGESOFTEN][vsdeinterlace.qtgmc.QTempGaussMC.SearchPostProcess.GAUSSBLUR_EDGESOFTEN].
-            range_expansion_args: Arguments passed to
-                [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range].
-            mask_shimmer_args: Arguments passed to the mask_shimmer call:
+            tr: Temporal radius of the binomial blur. Larger values reduce more shimmer but can introduce blurring and
+                ghosting. Defaults to 2.
+            sc_threshold: Threshold for scene changes. Higher values are less sensitive. Defaults to 0.1.
+            strength: Tuple containing the prefilter Gaussian blur sigma and blend weight.
 
-                   - erosion_distance: How much to deflate then reflate to remove thin areas.
-                     Default is 4 for this stage.
-                   - over_dilation: Extra inflation to ensure areas to restore back are fully caught.
-                     Default is 0.
+                - First value: Gaussian blur sigma. Higher values result in more blurring.
+                - Second value: Blend weight of the Gaussian blur. Higher values give more weight to the
+                    Gaussian-blurred clip.
+
+                Defaults to (1.9, 0.9).
+            limit: Tuple containing the 3-step limiting (8-bit) thresholds for the Gaussian blur post-processing:
+
+                   - First value: Maximum allowed delta between the temporally blurred clip and
+                   [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft]. Smaller values clamp
+                   [QTempGaussMC.draft][vsdeinterlace.QTempGaussMC.draft] closer to the temporally blurred clip.
+                   - Second value: Tolerance threshold for the allowed difference between the clamped clip and the
+                    Gaussian-blurred clip before hard clipping triggers. Larger values widen the allowed range for
+                    smooth blending before hard clipping is enforced.
+                   - Third value: Offset applied to the Gaussian-blurred clip when the second threshold is exceeded.
+                    Larger values allow a bigger delta from the Gaussian-blurred clip when clipped.
+
+                Defaults to (3, 7, 2).
+            bias: Weight used when blending the Gaussian-blurred clip back with the limited clip. Higher
+                values give more weight to the Gaussian-blurred clip. Defaults to 0.51.
+            range_expansion_args: Additional arguments passed to
+                [prefilter_to_full_range][vsdenoise.prefilters.prefilter_to_full_range]. Defaults to None.
+            mask_shimmer_args: Additional arguments passed to the internal `_mask_shimmer` call. Defaults to
+                {"erosion_distance": 4}.
         """
 
         self.prefilter_tr = tr
@@ -408,6 +425,9 @@ class QTempGaussMC(VSObject):
         self.prefilter_bias = bias
         self.prefilter_range_expansion_args = fallback(range_expansion_args, QTGMCArgs.PrefilterToFullRange())
         self.prefilter_mask_shimmer_args = fallback(mask_shimmer_args, QTGMCArgs.MaskShimmer())
+
+        if postprocess is not None and not postprocess.value:  # TODO: remove
+            self.prefilter_limit = (0, 0, 0)
 
         return self
 
@@ -423,20 +443,36 @@ class QTempGaussMC(VSObject):
         thscd: int | tuple[int | None, float | None] | None = (180, 38.5),
     ) -> Self:
         """
-        Configure parameters for the motion analysis stage.
+        Configures parameters for motion analysis.
+
+        Performs motion analysis, which is then utilized by all subsequent stages for motion-compensated processing.
+
+        High-level overview:
+            - Dynamic temporal radius calculation: Determines the maximum required temporal search radius across all
+                actively used settings and processes.
+            - Motion vector refinement: Iteratively shrinks block size and calls
+                [MVTools.recalculate][vsdenoise.mvtools.mvtools.MVTools.recalculate] to improve motion vector precision.
 
         Args:
-            force_tr: Always analyze motion to at least this, even if otherwise unnecessary.
-            preset: MVTools preset defining base values for the MVTools object.
-            blksize: Size of a block. Larger blocks are less sensitive to noise, are faster, but also less accurate.
-            overlap: The blksize divisor for block overlap. Larger overlapping reduces blocking artifacts.
-            refine: Number of times to recalculate motion vectors with halved block size.
-            thsad_recalc: Only bad quality new vectors with a SAD above this will be re-estimated by search. thsad value
-                is scaled to 8x8 block size.
-            thscd: Scene change detection thresholds:
+            force_tr: Always analyze motion to at least this value, even if otherwise unnecessary. Useful if you want to
+                reuse the generated motion vectors for other tasks. Defaults to 0.
+            preset: [MVTools][vsdenoise.mvtools.mvtools.MVTools] preset defining base values for
+                [MVTools][vsdenoise.mvtools.mvtools.MVTools]. Defaults to MVToolsPreset.HQ_SAD.
+            blksize: Motion analysis block size. Larger blocks are faster and less sensitive to noise, but less
+                accurate. Defaults to 16.
+            overlap: The block size divisor for block size overlap. Larger overlap reduces blocking artifacts of
+                [MVTools][vsdenoise.mvtools.mvtools.MVTools] processes. Defaults to 2.
+            refine: Number of iterations to recalculate motion vectors with halved block size. Improves motion vector
+                precision without reducing denoising effectiveness. Defaults to 1.
+            thsad_recalc: Only poor-quality new vectors with a SAD above this value will be re-estimated by motion
+                search. Only active when refine is used. Defaults to
+                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `thsad` / 2.
+            thscd: Scene-change detection thresholds:
 
                    - First value: SAD threshold for considering a block changed between frames.
                    - Second value: Percentage of changed blocks needed to trigger a scene change.
+
+                Defaults to (180, 38.5).
         """
 
         self.analyze_force_tr = force_tr
@@ -454,37 +490,68 @@ class QTempGaussMC(VSObject):
         *,
         tr: int = 1,
         func: DFTTest | _DenoiseFuncTr = DFTTest(sigma=8),
-        mode: NoiseProcessMode = NoiseProcessMode.IDENTIFY,
+        mode: NoiseProcessMode | None = None,
         deint: NoiseDeintMode = NoiseDeintMode.GENERATE,
+        full_denoise: bool = False,
         mc_denoise: bool = True,
         stabilize: float | Literal[False] = 0.4,
         func_comp_args: QTGMCArgs.Compensate | None = None,
         stabilize_comp_args: QTGMCArgs.Compensate | None = None,
     ) -> Self:
         """
-        Configure parameters for the denoise stage.
+        Configures parameters for the denoise stage.
+
+        Determines how to handle noise in the source, including extraction, removal, deinterlacing, and stabilization.
+
+        High-level overview:
+            - Noise handling approaches:
+                - Complete denoising: Denoise the source clip entirely, run the denoised clip through the standard
+                    deinterlacing routine, and optionally restore a portion of the original noise later in the
+                    algorithm.
+                - Noise extraction: Denoise the source clip solely to estimate the noise profile, run the source clip
+                    through the standard deinterlacing routine (which naturally reduces noise), and optionally restore a
+                    portion of the original noise later in the algorithm.
+
+            - Motion-compensated denoising: Motion compensation can optionally be used during the denoising to improve
+                the accuracy of the noise estimation.
+            - [[QTempGaussMC.deinterlace][vsdeinterlace.QTempGaussMC.deinterlace]] Interlaced noise processing: Because
+                the extracted noise is inherently interlaced and standard processing would eliminate it, three
+                alternative methods ([QTempGaussMC.NoiseDeintMode][vsdeinterlace.QTempGaussMC.NoiseDeintMode]) are
+                available to process it separately.
+            - Noise stabilization: The extracted noise can optionally be stabilized at the end of processing using a
+                blend of the maximum variance determined through motion compensation and the average of that maximum
+                variance and the extracted noise.
 
         Args:
-            tr: Temporal radius of the denoising function & it's motion compensation.
-            func: Denoising function to use.
-            mode: Noise handling method to use.
-            deint: Noise deinterlacing method to use.
-            mc_denoise: Whether to perform motion-compensated denoising.
-            stabilize: Weight to use when blending max noise variance with averaged noise.
-            func_comp_args: Arguments passed to [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for
-                denoising.
-            stabilize_comp_args: Arguments passed to [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate]
-                for stabilization.
+            tr: Temporal radius of the denoising function and its motion compensation. Larger values remove/separate
+                more noise. Defaults to 1.
+            func: Denoising function to use. Defaults to DFTTest(sigma=8).
+            deint: Specifies how to 'deinterlace' noise taken from an interlaced source before restoration. Defaults to
+                NoiseDeintMode.GENERATE.
+            full_denoise: Whether the denoised output will be directly used in all subsequent processing. If `False`,
+                the denoising is only for noise extraction. Defaults to False.
+            mc_denoise: Whether to motion-compensate the denoiser being used. Provides more accurate denoising/noise
+                extraction when using a non-motion-compensated temporal denoiser. Defaults to True.
+            stabilize: Weight used when blending max noise variance with averaged noise. Higher values give more
+                weight to the averaged noise. `False` disables stabilization. Defaults to 0.4.
+            func_comp_args: Additional arguments passed to
+                [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for denoising. Defaults to None.
+            stabilize_comp_args: Additional arguments passed to
+                [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for noise stabilization. Defaults to
+                None.
         """
 
         self.denoise_tr = tr
         self.denoise_func = func.denoise if isinstance(func, DFTTest) else func
-        self.denoise_mode = mode
         self.denoise_deint = deint
+        self.denoise_full_denoise = full_denoise
         self.denoise_mc_denoise = mc_denoise
         self.denoise_stabilize = stabilize
         self.denoise_func_comp_args = fallback(func_comp_args, QTGMCArgs.Compensate())
         self.denoise_stabilize_comp_args = fallback(stabilize_comp_args, QTGMCArgs.Compensate())
+
+        if mode is not None:  # TODO: remove
+            self.denoise_full_denoise = bool(mode)
 
         return self
 
@@ -500,22 +567,44 @@ class QTempGaussMC(VSObject):
         mask_shimmer_args: QTGMCArgs.MaskShimmer | None = {"erosion_distance": 0},
     ) -> Self:
         """
-        Configure parameters for the basic stage.
+        Configures parameters for the basic stage.
+
+        Creates the basic output of the core algorithm. Intended to eliminate bob shimmer.
+
+        High-level overview:
+            - High-quality bobbed clip generation: Begins with high-quality spatial interpolation to produce
+                [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], which inherently contains severe temporal
+                instability known as bob shimmer.
+            - [[QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]] Motion SAD masking: Generates a motion-vector
+                SAD mask to blend [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] output over
+                [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], protecting static/low-motion detail.
+            - Motion-compensated temporal binomial smoothing: Applies a motion-compensated temporal binomial blur to
+                smooth [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed], removing the shimmer while avoiding
+                ghosting artifacts.
+            - Shimmer masking: Uses a specialized masking process to eliminate the introduced blurring while retaining
+                the shimmer removal.
+            - Additional refinements: Passes the temporally smoothed clip through optional fine-tuning processes:
+                - [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match]
+                - [QTempGaussMC.lossless][vsdeinterlace.QTempGaussMC.lossless]
+                - [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen]
+                - [QTempGaussMC.back_blend][vsdeinterlace.QTempGaussMC.back_blend]
+                - [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit]
+
+            - Noise restoration: Optionally restores noise previously extracted by
+                [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of the pipeline.
 
         Args:
-            tr: Temporal radius of the motion compensated binomial smooth.
-            thsad: Thsad of the motion compensated binomial smooth.
-            bobber: Bobber to use for initial spatial interpolation.
-            noise_restore: How much noise to restore after this stage.
-            degrain_args: Arguments passed to the binomial_degrain call.
-            mask_args: Arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask] for
-                [repair][vsdeinterlace.qtgmc.QTempGaussMC.repair].
-            mask_shimmer_args: Arguments passed to the mask_shimmer call:
-
-                   - erosion_distance: How much to deflate then reflate to remove thin areas.
-                     Default is 0 for this stage.
-                   - over_dilation: Extra inflation to ensure areas to restore back are fully caught.
-                     Default is 0.
+            tr: Temporal radius of the motion-compensated binomial blur. Larger values reduce more shimmer but can
+                introduce blurring and ghosting. Defaults to 2.
+            thsad: SAD threshold of the motion-compensated binomial blur. Larger values reduce more shimmer but can
+                introduce blurring and ghosting. Defaults to 640.
+            bobber: Bobber to use for spatial interpolation. Defaults to NNEDI3(nsize=1).
+            noise_restore: Amount of noise to restore after this stage. Used to retain stable noise. Defaults to 0.
+            degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
+            mask_args: Additional arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]. Only used
+                for [QTempGaussMC.repair][vsdeinterlace.QTempGaussMC.repair]. Defaults to {"ml": 10}.
+            mask_shimmer_args: Additional arguments passed to the internal `_mask_shimmer` call. Defaults to
+                {"erosion_distance": 0}.
         """
 
         self.basic_tr = tr
@@ -535,29 +624,57 @@ class QTempGaussMC(VSObject):
         *,
         tr: int = 1,
         bobber: BobberLike | None = None,
-        mode: SourceMatchMode = SourceMatchMode.NONE,
+        iterations: Literal[0, 1, 2, 3] = 0,
+        mode: SourceMatchMode | None = None,
         similarity: float = 0.5,
         enhance: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
     ) -> Self:
         """
-        Configure parameters for the source_match stage.
+        Configures parameters for source match processing.
+
+        Creates higher-fidelity output with extra processing; acts as an alternative method for sharpness restoration.
+
+        High-level overview:
+            - Error-adjusted source matching: Computes a weighted error-correction factor based on temporal radius and
+                similarity, adjusting the input clip to compensate for the upcoming blur before re-interpolating and
+                applying smoothing.
+            - Detail enhancement: Optionally applies unsharpening to the result when `enhance` is used.
+            - Residual refinement pass: For multiple iterations, isolates the difference between the original input and
+                the current matched clip, interpolates and smooths this residual error (applying an additional
+                error-adjustment pass if `iterations` > 2), and merges it back to restore fine detail missed during the
+                initial pass.
+
+        Note:
+            - When source matching is used:
+                - [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen] is disabled by default, as source matching
+                    acts as an alternative form of sharpness restoration.
+                - [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit] is disabled by default, as it
+                    reduces the accuracy of source matching.
 
         Args:
-            tr: Temporal radius of the refinement motion compensated binomial smooth.
-            bobber: Bobber to use for refined spatial interpolation. Defaults to the basic bobber.
-            mode: Specifies number of refinement steps to perform.
-            similarity: Temporal similarity of the error created by smoothing.
-            enhance: Sharpening strength prior to source match refinement.
-            degrain_args: Arguments passed to the binomial_degrain call.
+            tr: Temporal radius of the refinement motion-compensated binomial blur. Larger values reduce more shimmer
+                but can introduce blurring and ghosting. Only used for `iterations` > 1. Defaults to 1.
+            bobber: Bobber to use for refined spatial interpolation. Only used for `iterations` > 1. Defaults to
+                [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `bobber`.
+            iterations: Number of source match iterations to perform. Higher values are slower and more accurate. Using
+                2 or 3 iterations restores almost exact source detail but is sensitive to noise and introduces
+                occasional aliasing (to a lesser extent for 3). Defaults to 0.
+            similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
+                Defaults to 0.5.
+            enhance: Enhances detail found by `iterations` > 1. Higher values exaggerate detail more. Defaults to 0.5.
+            degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
         """
 
         self.source_match_tr = tr
         self.source_match_bobber = bobber
-        self.source_match_mode = mode
+        self.source_match_iterations = iterations
         self.source_match_similarity = similarity
         self.source_match_enhance = enhance
         self.source_match_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
+
+        if mode is not None:  # TODO: remove
+            self.source_match_iterations = mode.value  # type: ignore
 
         return self
 
@@ -578,11 +695,20 @@ class QTempGaussMC(VSObject):
 
     def lossless(self, *, mode: LosslessMode = LosslessMode.NONE, anti_comb: bool = True) -> Self:
         """
-        Configure parameter for the lossless stage.
+        Configures parameters for lossless processing.
+
+        Restoring original fields significantly improves fidelity, but may introduce minor shimmering, combing,
+        or noise.
+
+        High-level overview:
+            - Source field weaving: Weaves the original fields together with the newly smoothed fields to preserve the
+                original lines, removing the original field alteration introduced by temporal blurring.
+            - Residual combing reduction: Applies vertical median filtering to clean up residual combing caused by
+                mismatches between the original fields and the processed fields.
 
         Args:
-            mode: Specifies at which stage to re-weave the original fields.
-            anti_comb: Whether to apply combing reduction post-processing.
+            mode: When to put the original fields into the output. Defaults to LosslessMode.NONE.
+            anti_comb: Whether to apply combing reduction post-processing. Defaults to True.
         """
 
         self.lossless_mode = mode
@@ -593,47 +719,66 @@ class QTempGaussMC(VSObject):
     def sharpen(
         self,
         *,
-        mode: SharpenMode = SharpenMode.UNSHARP_MINMAX,
+        mode: SharpenMode | None = None,
         strength: float | None = None,
-        clamp: float | tuple[float, float] = 1,
+        offset: float | tuple[float, float] | Literal[False] = 1,
         thin: float = 0,
     ) -> Self:
         """
-        Configure parameters for the sharpen stage.
+        Configures parameters for sharpening.
+
+        Re-sharpens the output after temporal smoothing is performed.
+
+        High-level overview:
+            - Pre-blur range limiting: Calculates the local vertical average and offsets it prior to applying the blur
+                used for unsharpening to increase vertical sharpening while reducing overshoot/undershoot.
+            - Unsharpening: Applies unsharpening onto the temporally smoothed clip to restore image sharpness.
+            - Horizontal edge thinning: Optionally thins horizontal edges that have been widened due to interpolation
+                into neighboring field lines.
 
         Args:
-            mode: Specifies the type of sharpening to use.
-                Defaults to [SharpenMode.UNSHARP_MINMAX][vsdeinterlace.qtgmc.QTempGaussMC.SharpenMode.UNSHARP_MINMAX].
-            strength: Sharpening strength. Defaults to 1 for
-                [SourceMatchMode.NONE][vsdeinterlace.qtgmc.QTempGaussMC.SourceMatchMode.NONE] or 0 otherwise.
-            clamp: Clamp the sharpening strength of
-                [SharpenMode.UNSHARP_MINMAX][vsdeinterlace.qtgmc.QTempGaussMC.SharpenMode.UNSHARP_MINMAX] to the min/max
-                average plus/minus this.
-            thin: How much to thin horizontal edges.
+            strength: Sharpening strength. Higher values result in more sharpening. Defaults to 1 when
+                [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0, and 0 otherwise.
+            offset: Offsets the blur source to the vertical min/max average ±this value. Smaller values result in more
+                vertical sharpening. Passing a tuple of values results in asymmetric offsetting. `False` disables
+                range limiting. Defaults to 1.
+            thin: How much to thin down horizontal edges. Higher values result in more thinning. Defaults to 0.
         """
 
-        self.sharpen_mode = mode
         self.sharpen_strength = strength
-        self.sharpen_clamp = normalize_seq(clamp, 2)
+        self.sharpen_offset = offset is not False and normalize_seq(offset, 2)
         self.sharpen_thin = thin
+
+        if mode is not None and not mode.value:  # TODO: remove
+            self.sharpen_offset = False
 
         return self
 
     @property
     def sharpen_strength(self) -> float:
-        return fallback(self._sharpen_strength, 0 if self.source_match_mode else 1)
+        return fallback(self._sharpen_strength, 0 if self.source_match_iterations else 1)
 
     @sharpen_strength.setter
     def sharpen_strength(self, value: float | None) -> None:
         self._sharpen_strength = value
 
-    def back_blend(self, *, mode: BackBlendMode = BackBlendMode.PRELIMIT, sigma: float = 1.4) -> Self:
+    def back_blend(self, *, mode: BackBlendMode = BackBlendMode.BOTH, sigma: float = 1.4) -> Self:
         """
-        Configure parameters for the back_blend stage.
+        Configures parameters for back-blending.
+
+        Improves [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen] fidelity by dampening low-frequency
+        enhancement caused by unsharpening.
+
+        High-level overview:
+            - Low-frequency back-blending: Gaussian-blurs the pre- and post-sharpening difference to isolate broad
+                low-frequency shifts, then merges that blurred difference back onto the source to preserve only
+                high-frequency edge sharpening.
 
         Args:
-            mode: Specifies at which stage to perform back-blending.
-            sigma: Gaussian blur sigma.
+            mode: When to back-blend the (blurred) difference between the pre- and post-sharpened clips. Defaults to
+                BackBlendMode.BOTH.
+            sigma: Gaussian blur sigma applied to the pre- and post-sharpening difference. Lower values dampen
+                sharpening more aggressively. Defaults to 1.4.
         """
 
         self.backblend_mode = mode
@@ -644,37 +789,53 @@ class QTempGaussMC(VSObject):
     def sharpen_limit(
         self,
         *,
-        mode: SharpenLimitMode = SharpenLimitMode.TEMPORAL_PRESMOOTH,
-        radius: int | None = None,
+        mode: SharpenLimitMode | None = None,
+        radius: int = 1,
         clamp: float | tuple[float, float] = 0,
         comp_args: QTGMCArgs.Compensate | None = None,
     ) -> Self:
         """
-        Configure parameters for the sharpen_limit stage.
+        Configures parameters for sharpness limiting.
+
+        Limits the effect of [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen] to reduce oversharpening
+        artifacts.
+
+        High-level overview:
+            - Sharpness limiting approaches:
+                - Spatial limiting: Clamps the sharpened clip's pixel values to the local spatial minimum and maximum
+                    bounds of [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed].
+                - Motion-compensated temporal limiting: Clamps the sharpened clip using motion-compensated reference
+                    frames from [QTempGaussMC.bobbed][vsdeinterlace.QTempGaussMC.bobbed].
 
         Args:
-            mode: Specifies type of limiting & at which stage to perform it.
-            radius: Radius of sharpness limiting. Defaults to 1 for
-                [SourceMatchMode.NONE][vsdeinterlace.qtgmc.QTempGaussMC.SourceMatchMode.NONE] or 0 otherwise.
-            clamp: How much undershoot/overshoot to allow.
-            comp_args: Arguments passed to [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate] for
-                temporal limiting.
+            mode: How and when to apply limiting to [QTempGaussMC.sharpen][vsdeinterlace.QTempGaussMC.sharpen]. Defaults
+                to SharpenLimitMode.TEMPORAL_PRESMOOTH when
+                [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match] `iterations` is 0 and
+                SharpenLimitMode.NONE otherwise.
+            radius: Radius of the sharpness limiting. Larger values allow more sharpening. Defaults to 1.
+            clamp: How much undershoot/overshoot to allow. Larger values result in less limiting. Passing a tuple of
+                values allows for asymmetric limiting. Defaults to 0.
+            comp_args: Additional arguments passed to [MVTools.compensate][vsdenoise.mvtools.mvtools.MVTools.compensate]
+                for temporal limiting. Defaults to None.
         """
 
         self.sharpen_limit_mode = mode
         self.sharpen_limit_radius = radius
-        self.sharpen_limit_clamp = clamp
+        self.sharpen_limit_clamp = normalize_seq(clamp, 2)
         self.sharpen_limit_comp_args = fallback(comp_args, QTGMCArgs.Compensate())
 
         return self
 
     @property
-    def sharpen_limit_radius(self) -> int:
-        return fallback(self._sharpen_limit_radius, 0 if self.source_match_mode else 1)
+    def sharpen_limit_mode(self) -> SharpenLimitMode:
+        return fallback(
+            self._sharpen_limit_mode,
+            self.SharpenLimitMode.NONE if self.source_match_iterations else self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
+        )
 
-    @sharpen_limit_radius.setter
-    def sharpen_limit_radius(self, value: int | None) -> None:
-        self._sharpen_limit_radius = value
+    @sharpen_limit_mode.setter
+    def sharpen_limit_mode(self, value: SharpenLimitMode | None) -> None:
+        self._sharpen_limit_mode = value
 
     def final(
         self,
@@ -686,19 +847,32 @@ class QTempGaussMC(VSObject):
         mask_shimmer_args: QTGMCArgs.MaskShimmer | None = {"erosion_distance": 4},
     ) -> Self:
         """
-        Configure parameters for the final stage.
+        Configures parameters for the final stage.
+
+        Creates the final output of the core algorithm. Intended to eliminate residual artifacts.
+
+        High-level overview:
+            - Motion-compensated temporal linear smoothing: Applies a motion-compensated temporal linear blur to smooth
+                the output of [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic], cleaning any residual artifacts.
+            - Shimmer masking: Uses a specialized masking process to eliminate the introduced blurring while retaining
+                the artifact removal.
+            - Additional refinements: Passes the temporally smoothed clip through optional fine-tuning processes:
+                - [QTempGaussMC.sharpen_limit][vsdeinterlace.QTempGaussMC.sharpen_limit]
+                - [QTempGaussMC.lossless][vsdeinterlace.QTempGaussMC.lossless]
+
+            - Noise restoration: Optionally restores noise previously extracted by
+                [QTempGaussMC.denoise][vsdeinterlace.QTempGaussMC.denoise] at the end of the pipeline.
 
         Args:
-            tr: Temporal radius of the motion compensated smooth.
-            thsad: Thsad of the motion compensated smooth.
-            noise_restore: How much noise to restore after this stage.
-            degrain_args: Arguments passed to [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain].
-            mask_shimmer_args: Arguments passed to the mask_shimmer call:
-
-                   - erosion_distance: How much to deflate then reflate to remove thin areas.
-                     Default is 4 for this stage.
-                   - over_dilation: Extra inflation to ensure areas to restore back are fully caught.
-                     Default is 0.
+            tr: Temporal radius of the motion-compensated linear blur. Larger values clean more artifacts but can
+                introduce blurring and ghosting. Defaults to 1.
+            thsad: SAD threshold of the motion-compensated linear blur. Larger values clean more artifacts but can
+                introduce blurring and ghosting. Defaults to 256.
+            noise_restore: Amount of noise to restore after this stage. Used to retain any noise. Defaults to 0.
+            degrain_args: Additional arguments passed to [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain].
+                Defaults to None.
+            mask_shimmer_args: Additional arguments passed to the internal `_mask_shimmer` call. Defaults to
+                {"erosion_distance": 4}.
         """
 
         self.final_tr = tr
@@ -718,14 +892,28 @@ class QTempGaussMC(VSObject):
         mask_args: QTGMCArgs.Mask | None = {"ml": 4},
     ) -> Self:
         """
-        Configure parameters for the motion blur stage.
+        Configures parameters for the motion blur stage.
+
+        Simulates realistic camera shutter blur to smooth playback motion, primarily when reducing output frame rate.
+
+        High-level overview:
+            - Shutter angle calculation: Computes the required blur intensity based on the estimated input shutter
+                angle, the output shutter angle, and the frame rate divisor.
+            - Motion-compensated blurring: Applies vector-based directional blur along motion vectors when the required
+                blur amount is non-zero.
+            - Motion-adaptive masking: Generates a mask based on motion to selectively merge motion blur into the source
+                while keeping static areas sharp.
+            - Frame rate reduction: Optionally decimates frame rate (e.g., dropping every other frame for single-rate
+                output) after motion blur application.
 
         Args:
-            shutter_angle: Tuple containing the source and output shutter angle. Will apply motion blur if they do not
-                match.
-            fps_divisor: Factor by which to reduce framerate.
-            blur_args: Arguments passed to [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur].
-            mask_args: Arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask].
+            shutter_angle: Tuple containing the source and output shutter angles. Motion blur is applied if they do not
+                match. Defaults to (180, 180).
+            fps_divisor: Factor by which to smoothly reduce frame rate. Defaults to 1.
+            blur_args: Additional arguments passed to [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur].
+                Defaults to None.
+            mask_args: Additional arguments passed to [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]. Defaults
+                to {"ml": 4}.
         """
 
         self.motion_blur_shutter_angle = shutter_angle
@@ -742,16 +930,6 @@ class QTempGaussMC(VSObject):
         erosion_distance: int,
         over_dilation: int = 0,
     ) -> vs.VideoNode:
-        """
-        Removes areas of difference between a temporally smoothed clip and reference that are not due to bob-shimmer by
-        only allowing thin horizontal areas of difference.
-
-        Args:
-            flt: Processed clip to perform masking on.
-            src: Unprocessed clip to restore from.
-            erosion_distance: How much to deflate then reflate to remove thin areas.
-            over_dilation: Extra inflation to ensure areas to restore back are fully caught.
-        """
         if not erosion_distance:
             return flt
 
@@ -814,36 +992,30 @@ class QTempGaussMC(VSObject):
             search = self.draft
 
         if self.prefilter_tr:
-            scenes = sc_detect(search, self.prefilter_sc_threshold)
             smoothed = BlurMatrix.BINOMIAL(self.prefilter_tr, mode=ConvMode.TEMPORAL)(
-                scenes, scenechange=True, func=self._apply_prefilter
+                sc_detect(search, self.prefilter_sc_threshold), scenechange=True, func=self._apply_prefilter
             )
             smoothed = self._mask_shimmer(smoothed, search, **self.prefilter_mask_shimmer_args)
         else:
             smoothed = search
 
-        if self.prefilter_strength:
-            gauss_sigma, blend_weight = self.prefilter_strength
+        gauss_sigma, blend_weight = self.prefilter_strength
+        lim1, lim2, lim3 = [scale_delta(thr, 8, self.clip) for thr in self.prefilter_limit]
 
-            blurred = core.std.Merge(gauss_blur(smoothed, gauss_sigma), smoothed, blend_weight)
-
-            if self.prefilter_postprocess == self.SearchPostProcess.GAUSSBLUR_EDGESOFTEN:
-                lim1, lim2, lim3 = [scale_delta(thr, 8, self.clip) for thr in self.prefilter_limit]
-
-                blurred = norm_expr(
-                    [blurred, smoothed, search],
-                    "z y {lim1} - y {lim1} + clamp TWEAK! "
-                    "x {lim2} + TWEAK@ < x {lim3} + x {lim2} - TWEAK@ > x {lim3} - "
-                    "x {weight1} * TWEAK@ {weight2} * + ? ?",
-                    lim1=lim1,
-                    lim2=lim2,
-                    lim3=lim3,
-                    weight1=self.prefilter_bias,
-                    weight2=1 - self.prefilter_bias,
-                    func=self._apply_prefilter,
-                )
-        else:
-            blurred = smoothed
+        # TODO: Figure out early exits
+        blurred = gauss_blur(smoothed, gauss_sigma) if gauss_sigma and blend_weight else smoothed
+        blurred = norm_expr(
+            [blurred, smoothed, search],
+            "y x y - {weight} * + BLUR! z y {lim1} - y {lim1} + clamp TWEAK! "
+            "BLUR@ {lim2} + TWEAK@ < BLUR@ {lim3} + BLUR@ {lim2} - TWEAK@ > BLUR@ {lim3} - "
+            "TWEAK@ BLUR@ TWEAK@ - {bias} * + ? ?",
+            weight=blend_weight,
+            lim1=lim1,
+            lim2=lim2,
+            lim3=lim3,
+            bias=self.prefilter_bias,
+            func=self._apply_prefilter,
+        )
 
         self.prefilter_output = prefilter_to_full_range(
             blurred, func=self._apply_prefilter, **self.prefilter_range_expansion_args
@@ -862,34 +1034,34 @@ class QTempGaussMC(VSObject):
             self.denoise_tr if self.denoise_mc_denoise else 0,
             self.sharpen_limit_radius
             if self.sharpen_limit_mode
-            in (self.SharpenLimitMode.TEMPORAL_PRESMOOTH, self.SharpenLimitMode.TEMPORAL_POSTSMOOTH)
+            in {self.SharpenLimitMode.TEMPORAL_PRESMOOTH, self.SharpenLimitMode.TEMPORAL_POSTSMOOTH}
             and (self.sharpen_strength or self.sharpen_thin)
             else 0,
             # Feature flags
-            int(self.denoise_stabilize is not False),
+            int(self.denoise_stabilize is not False and (self.basic_noise_restore or self.final_noise_restore)),
             int(bool(self.is_repair and self.basic_mask_args.get("ml"))),
             int(angle_out * self.motion_blur_fps_divisor != angle_in),
         )
 
-        blksize, overlap = self.analyze_blksize, self.analyze_overlap
+        blksize = self.analyze_blksize
         thsad_recalc = fallback(
             self.analyze_thsad_recalc,
             round((self.basic_thsad[0] if isinstance(self.basic_thsad, tuple) else self.basic_thsad) / 2),
         )
 
         self.mv = MVTools(self.draft, **{**self.analyze_preset, "search_clip": self.prefilter_output})
-        self.mv.analyze(tr=tr, blksize=blksize, overlap_div=overlap)
+        self.mv.analyze(tr=tr, blksize=blksize, overlap_div=self.analyze_overlap)
 
         for _ in range(self.analyze_refine):
             blksize = refine_blksize(blksize)
-            self.mv.recalculate(thsad=thsad_recalc, blksize=blksize, overlap_div=overlap)
+            self.mv.recalculate(thsad=thsad_recalc, blksize=blksize, overlap_div=self.analyze_overlap)
 
     def _apply_denoise(self) -> None:
         self.denoise_output = self.clip
 
         no_restore = self.basic_noise_restore == self.final_noise_restore == 0
 
-        if self.denoise_mode == self.NoiseProcessMode.IDENTIFY and no_restore:
+        if not self.denoise_full_denoise and no_restore:
             return
 
         if self.denoise_mc_denoise:
@@ -905,7 +1077,7 @@ class QTempGaussMC(VSObject):
         if self.tff.is_inter and not self.is_repair:
             denoised = reinterlace(denoised, self.tff, self._apply_denoise)
 
-        if self.denoise_mode == self.NoiseProcessMode.DENOISE:
+        if self.denoise_full_denoise:
             self.denoise_output = denoised
 
         self.noise = self.clip.std.MakeDiff(denoised)
@@ -953,9 +1125,9 @@ class QTempGaussMC(VSObject):
 
             self.noise = norm_expr(
                 [self.noise, *noise_comp],
-                "x neutral - abs y neutral - abs > x y ? {weight1} * x y + {weight2} * +",
-                weight1=1 - self.denoise_stabilize,
-                weight2=self.denoise_stabilize / 2,
+                "x neutral - abs y neutral - abs > x y ? {weight2} * x y + {weight1} * +",
+                weight1=self.denoise_stabilize / 2,
+                weight2=1 - self.denoise_stabilize,
                 func=self._apply_denoise,
             )
 
@@ -977,10 +1149,11 @@ class QTempGaussMC(VSObject):
             self.bobbed = self.denoise_output.std.MaskedMerge(self.bobbed, mask)
 
         smoothed = self._binomial_degrain(self.bobbed, self.basic_tr, **self.basic_degrain_args)
+
         if self.basic_tr:
             smoothed = self._mask_shimmer(smoothed, self.bobbed, **self.basic_mask_shimmer_args)
 
-            if self.source_match_mode:
+            if self.source_match_iterations:
                 smoothed = self._apply_source_match(smoothed)
 
         if self.lossless_mode == self.LosslessMode.PRESHARPEN:
@@ -988,16 +1161,18 @@ class QTempGaussMC(VSObject):
 
         resharp = self._apply_sharpen(smoothed)
 
-        if self.backblend_mode in (self.BackBlendMode.PRELIMIT, self.BackBlendMode.BOTH):
-            resharp = self._apply_back_blend(resharp, smoothed)
-
-        if self.sharpen_limit_mode in (
+        if self.sharpen_limit_mode in {
             self.SharpenLimitMode.SPATIAL_PRESMOOTH,
             self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
-        ):
+        }:
+            if self.backblend_mode in {self.BackBlendMode.PRELIMIT, self.BackBlendMode.BOTH}:
+                resharp = self._apply_back_blend(resharp, smoothed)
+
             resharp = self._apply_sharpen_limit(resharp)
 
-        if self.backblend_mode in (self.BackBlendMode.POSTLIMIT, self.BackBlendMode.BOTH):
+            if self.backblend_mode in {self.BackBlendMode.POSTLIMIT, self.BackBlendMode.BOTH}:
+                resharp = self._apply_back_blend(resharp, smoothed)
+        elif self.backblend_mode != self.BackBlendMode.NONE:
             resharp = self._apply_back_blend(resharp, smoothed)
 
         self.basic_output = self._apply_noise_restore(resharp, self.basic_noise_restore)
@@ -1009,12 +1184,10 @@ class QTempGaussMC(VSObject):
 
             tr_f = 2 * tr - 1
             tr_s = 2**tr_f
-            binomial_coeff = math.comb(tr_f, tr)
+            binomial_coeff = comb(tr_f, tr)
             error_adj = tr_s / (binomial_coeff + self.source_match_similarity * (tr_s - binomial_coeff))
 
-            return norm_expr(
-                [ref, clip], "x {adj1} * y {adj2} * -", adj1=error_adj + 1, adj2=error_adj, func=_error_adjustment
-            )
+            return norm_expr([ref, clip], "x x y - {error_adj} * +", error_adj=error_adj, func=_error_adjustment)
 
         if self.tff.is_inter:
             clip = reinterlace(clip, self.tff, self._apply_source_match)
@@ -1023,7 +1196,7 @@ class QTempGaussMC(VSObject):
         new_bobbed = self._interpolate(adjusted, self.basic_bobber)
         matched = self._binomial_degrain(new_bobbed, self.basic_tr, **self.basic_degrain_args)
 
-        if self.source_match_mode > self.SourceMatchMode.BASIC:
+        if self.source_match_iterations > 1:
             if self.source_match_enhance:
                 matched = unsharpen(
                     matched, self.source_match_enhance, BlurMatrix.BINOMIAL(), func=self._apply_source_match
@@ -1037,7 +1210,7 @@ class QTempGaussMC(VSObject):
                 refine_bobbed, self.source_match_tr, **self.source_match_degrain_args
             )
 
-            if self.source_match_mode == self.SourceMatchMode.TWICE_REFINED:
+            if self.source_match_iterations > 2:
                 refine_adjusted = _error_adjustment(refine_bobbed, refine_matched, self.source_match_tr)
                 refine_matched = self._binomial_degrain(
                     refine_adjusted, self.source_match_tr, **self.source_match_degrain_args
@@ -1048,7 +1221,7 @@ class QTempGaussMC(VSObject):
         return matched
 
     def _apply_lossless(self, clip: vs.VideoNode) -> vs.VideoNode:
-        if not self.tff.is_inter:
+        if not self.tff.is_inter or clip is self.bobbed:
             return clip
 
         fields_src = self.denoise_output.std.SeparateFields(self.tff.is_tff)
@@ -1059,18 +1232,16 @@ class QTempGaussMC(VSObject):
         woven = reweave(fields_src, fields_flt, self.tff.field, self._apply_lossless)
 
         if self.lossless_anti_comb:
-            median_diff = woven.std.MakeDiff(median_blur(woven, mode=ConvMode.VERTICAL, func=self._apply_lossless))
+            median_diff = median_blur(woven, mode=ConvMode.VERTICAL, func=self._apply_lossless).std.MakeDiff(woven)
             fields_diff = median_diff.std.SeparateFields(self.tff.is_tff).std.SelectEvery(4, (1, 2))
 
-            processed_diff = norm_expr(
+            cleaned_diff = norm_expr(
                 [median_blur(fields_diff, mode=ConvMode.VERTICAL, func=self._apply_lossless), fields_diff],
                 "x neutral - X! y neutral - Y! X@ Y@ xor neutral X@ abs Y@ abs < x y ? ?",
                 func=self._apply_lossless,
             )
-            processed_diff = repair.Mode.MINMAX_SQUARE1(
-                processed_diff, remove_grain.Mode.MINMAX_AROUND2(processed_diff)
-            )
-            woven = reweave(fields_src, fields_flt.std.MakeDiff(processed_diff), self.tff.field, self._apply_lossless)
+            cleaned_diff = repair.Mode.MINMAX_SQUARE1(cleaned_diff, remove_grain.Mode.MINMAX_AROUND2(cleaned_diff))
+            woven = reweave(fields_src, fields_flt.std.MergeDiff(cleaned_diff), self.tff.field, self._apply_lossless)
 
         return FieldBased.PROGRESSIVE.apply(woven)
 
@@ -1078,27 +1249,26 @@ class QTempGaussMC(VSObject):
         resharp = clip
 
         if self.sharpen_strength:
-            if self.sharpen_mode == self.SharpenMode.UNSHARP:
-                resharp = unsharpen(clip, self.sharpen_strength, BlurMatrix.BINOMIAL(), func=self._apply_sharpen)
-            elif self.sharpen_mode == self.SharpenMode.UNSHARP_MINMAX:
-                undershoot, overshoot = self.sharpen_clamp
+            if self.sharpen_offset is not False:
+                dark_offset, bright_offset = self.sharpen_offset
 
                 source_min = Morpho.minimum(clip, coords=Coordinates.VERTICAL, func=self._apply_sharpen)
                 source_max = Morpho.maximum(clip, coords=Coordinates.VERTICAL, func=self._apply_sharpen)
 
-                clamp = norm_expr(
+                resharp = norm_expr(
                     [clip, source_min, source_max],
-                    "y z + 2 / AVG! AVG@ x > AVG@ {undershoot} - AVG@ x < AVG@ {overshoot} + x ? ?",
-                    undershoot=scale_delta(undershoot, 8, clip),
-                    overshoot=scale_delta(overshoot, 8, clip),
+                    "y z + 2 / AVG! AVG@ x > AVG@ {dark_offset} - AVG@ x < AVG@ {bright_offset} + x ? ?",
+                    dark_offset=scale_delta(dark_offset, 8, clip),
+                    bright_offset=scale_delta(bright_offset, 8, clip),
                     func=self._apply_sharpen,
                 )
-                resharp = unsharpen(
-                    clip,
-                    self.sharpen_strength,
-                    BlurMatrix.BINOMIAL()(clamp, func=self._apply_sharpen),
-                    func=self._apply_sharpen,
-                )
+
+            resharp = unsharpen(
+                clip,
+                self.sharpen_strength,
+                BlurMatrix.BINOMIAL()(resharp, func=self._apply_sharpen),
+                func=self._apply_sharpen,
+            )
 
         if self.sharpen_thin:
             median_diff = norm_expr(
@@ -1118,18 +1288,20 @@ class QTempGaussMC(VSObject):
         return resharp
 
     def _apply_back_blend(self, flt: vs.VideoNode, src: vs.VideoNode) -> vs.VideoNode:
-        if self.backblend_sigma and (self.sharpen_strength or self.sharpen_thin):
-            flt = flt.std.MakeDiff(gauss_blur(flt.std.MakeDiff(src), self.backblend_sigma))
+        if self.sharpen_strength or self.sharpen_thin:
+            flt = src.std.MergeDiff(gauss_blur(flt.std.MakeDiff(src), self.backblend_sigma))
 
         return flt
 
     def _apply_sharpen_limit(self, clip: vs.VideoNode) -> vs.VideoNode:
-        if self.sharpen_limit_radius and (self.sharpen_strength or self.sharpen_thin):
-            if self.sharpen_limit_mode in (
+        undershoot, overshoot = self.sharpen_limit_clamp
+
+        if self.sharpen_strength or self.sharpen_thin:
+            if self.sharpen_limit_mode in {
                 self.SharpenLimitMode.SPATIAL_PRESMOOTH,
                 self.SharpenLimitMode.SPATIAL_POSTSMOOTH,
-            ):
-                if self.sharpen_limit_radius == 1:
+            }:
+                if self.sharpen_limit_radius == 1 and undershoot == overshoot == 0:
                     clip = repair.Mode.MINMAX_SQUARE1(clip, self.bobbed)
                 else:
                     inpand = Morpho.minimum(
@@ -1138,16 +1310,22 @@ class QTempGaussMC(VSObject):
                     expand = Morpho.maximum(
                         self.bobbed, iterations=self.sharpen_limit_radius, func=self._apply_sharpen_limit
                     )
-                    clip = ExprOp.CLAMP(clip, inpand, expand, func=self._apply_sharpen_limit)
-            elif self.sharpen_limit_mode in (
+                    clip = norm_expr(
+                        [clip, inpand, expand],
+                        "x y {undershoot} - z {overshoot} + clamp",
+                        undershoot=undershoot,
+                        overshoot=overshoot,
+                        func=self._apply_sharpen_limit,
+                    )
+            elif self.sharpen_limit_mode in {
                 self.SharpenLimitMode.TEMPORAL_PRESMOOTH,
                 self.SharpenLimitMode.TEMPORAL_POSTSMOOTH,
-            ):
+            }:
                 clip = mc_clamp(
                     clip,
                     self.bobbed,
                     self.mv,
-                    self.sharpen_limit_clamp,
+                    (undershoot, overshoot),
                     self._apply_sharpen_limit,
                     tr=self.sharpen_limit_radius,
                     thscd=self.analyze_thscd,
@@ -1175,12 +1353,14 @@ class QTempGaussMC(VSObject):
             )
         else:
             smoothed = self.basic_output
-        smoothed = self._mask_shimmer(smoothed, self.bobbed, **self.final_mask_shimmer_args)
 
-        if self.sharpen_limit_mode in (
+        if smoothed is not self.bobbed:
+            smoothed = self._mask_shimmer(smoothed, self.bobbed, **self.final_mask_shimmer_args)
+
+        if self.sharpen_limit_mode in {
             self.SharpenLimitMode.SPATIAL_POSTSMOOTH,
             self.SharpenLimitMode.TEMPORAL_POSTSMOOTH,
-        ):
+        }:
             smoothed = self._apply_sharpen_limit(smoothed)
 
         if self.lossless_mode == self.LosslessMode.POSTSMOOTH:
@@ -1263,10 +1443,13 @@ class QTempGaussMC(VSObject):
 
     def deinterlace(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
-        Deinterlace interlaced input. Motion blur stage FPS divisor is respected.
+        Deinterlace interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor`
+        is respected.
+
+        Interpolates missing fields to reconstruct progressive frames.
 
         Args:
-            clip: Input clip.
+            clip: Clip to process.
             tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
 
         Returns:
@@ -1276,10 +1459,13 @@ class QTempGaussMC(VSObject):
 
     def bob(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
         """
-        Bob interlaced input. Motion blur stage FPS divisor is ignored.
+        Bob interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is
+        ignored.
+
+        Interpolates missing fields to reconstruct double-framerate progressive frames.
 
         Args:
-            clip: Input clip.
+            clip: Clip to process.
             tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
 
         Returns:
@@ -1292,8 +1478,10 @@ class QTempGaussMC(VSObject):
         """
         Repair badly deinterlaced input.
 
+        Drops half the fields to recreate an interlaced stream using the remaining ones.
+
         Args:
-            clip: Input clip.
+            clip: Clip to process.
             tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
 
         Returns:
@@ -1305,8 +1493,10 @@ class QTempGaussMC(VSObject):
         """
         Deshimmer progressive input.
 
+        Removes horizontal shimmering artifacts from progressive sources.
+
         Args:
-            clip: Input clip.
+            clip: Clip to process.
 
         Returns:
             Deshimmered clip.

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -53,12 +53,7 @@ class QTGMCArgs:
     """Namespace containing helper TypedDict definitions for various argument groups."""
 
     class MaskShimmer(TypedDict, total=False):
-        """
-        Arguments accepted by [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer] through
-        [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter],
-        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
-        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
-        """
+        """Arguments accepted by [mask_shimmer][vsdeinterlace.qtgmc.mask_shimmer]."""
 
         erosion_distance: int
         over_dilation: int
@@ -76,13 +71,7 @@ class QTGMCArgs:
         time: float | None
 
     class Degrain(TypedDict, total=False):
-        """
-        Arguments accepted by the internal `binomial_degrain` method, calling
-        [MVTools.degrain][vsdenoise.mvtools.mvtools.MVTools.degrain] through
-        [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] and
-        [QTempGaussMC.source_match][vsdeinterlace.QTempGaussMC.source_match], or directly through
-        [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final].
-        """
+        """Arguments accepted by the internal `binomial_degrain` method."""
 
         limit: float | tuple[float, float] | None
         planes: Planes
@@ -1450,10 +1439,10 @@ class QTempGaussMC(_QTGMCBuilder):
         self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
     ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
         """
-        Deinterlace interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor`
-        is respected.
+        Deinterlace interlaced input.
 
         Interpolates missing fields to reconstruct progressive frames.
+        [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is respected.
 
         Args:
             clip: Clip to process.
@@ -1496,10 +1485,10 @@ class QTempGaussMC(_QTGMCBuilder):
         self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
     ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
         """
-        Bob interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is
-        ignored.
+        Bob interlaced input.
 
         Interpolates missing fields to reconstruct progressive frames.
+        [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is ignored.
 
         Args:
             clip: Clip to process.
@@ -1603,8 +1592,7 @@ def mask_shimmer(
     func: FuncExcept | None = None,
 ) -> vs.VideoNode:
     """
-    Removes areas of difference between a temporally blurred clip and a reference clip that are not due to
-    bob shimmer by only allowing thin horizontal areas of difference.
+    Filters out differences unrelated to bob shimmer by isolating only thin horizontal areas.
 
     High-level overview:
         - Vertical morphological analysis: Extracts the difference between source and filtered clips, running

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -959,7 +959,7 @@ class QTGMCGraph(VSObject):
         prefilter = graph.prefilter
         ```
 
-    Additional usage info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Additional usage info: [JET Encoding Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     class Mode(CustomIntEnum):
@@ -1590,7 +1590,7 @@ class QTempGaussMC(_QTGMCBuilder):
         deinterlaced = QTempGaussMC().lossless(QTempGaussMC.LosslessMode.PRESHARPEN).final(tr=2).deinterlace(clip)
         ```
 
-    Additional usage info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Additional usage info: [JET Encoding Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     @overload

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -885,28 +885,12 @@ class _QTGMCBuilder:
         return self
 
     @property
-    def _noise_restore_enabled(self) -> bool:
-        return bool(self.basic_noise_restore or self.final_noise_restore)
-
-    @property
-    def _mc_denoise_tr(self) -> int:
-        return (
-            self.denoise_tr
-            if self.denoise_mc_denoise and (self.denoise_full_denoise or self._noise_restore_enabled)
-            else 0
-        )
-
-    @property
-    def _stabilization_enabled(self) -> bool:
-        return self.denoise_stabilize is not False and self._noise_restore_enabled
-
-    @property
     def _source_match_enabled(self) -> bool:
         return bool(self.source_match_iterations and self.basic_tr)
 
     @property
     def _sharpen_sigma(self) -> float:
-        # Combined variance of the (binomial) basic blur and (linear) final blur.
+        # Total variance of the (binomial) basic blur and (linear) final blur.
         return sqrt(self.basic_tr / 2 + self.final_tr * (self.final_tr + 1) / 3)
 
     @property
@@ -933,6 +917,10 @@ class _QTGMCBuilder:
             and self.sharpen_limit_radius
             and self._sharpening_enabled
         )
+
+    @property
+    def _noise_restore_enabled(self) -> bool:
+        return bool(self.basic_noise_restore or self.final_noise_restore)
 
 
 class QTGMCGraph(VSObject):
@@ -1135,12 +1123,15 @@ class QTGMCGraph(VSObject):
 
         tr = max(
             self.settings.analyze_force_tr,
-            self.settings._mc_denoise_tr,
-            self.settings._stabilization_enabled,
-            self.settings.basic_tr,
+            self.settings.denoise_tr
+            if self.settings.denoise_mc_denoise
+            and (self.settings.denoise_full_denoise or self.settings._noise_restore_enabled)
+            else 0,
+            self.settings.denoise_stabilize is not False and self.settings._noise_restore_enabled,
             self._repair_mask_enabled,
+            self.settings.basic_tr,
             self.settings.source_match_tr
-            if self.settings.source_match_iterations > 1 and self.settings._source_match_enabled
+            if self.settings.source_match_iterations > 1 and self.settings.basic_tr
             else 0,
             self.settings.sharpen_limit_radius
             if self.settings.sharpen_limit_mode.is_temporal and self.settings._sharpness_limiting_enabled
@@ -1207,7 +1198,7 @@ class QTGMCGraph(VSObject):
 
             noise = FieldBased.PROGRESSIVE.apply(noise)
 
-        if self.settings._stabilization_enabled:
+        if self.settings.denoise_stabilize is not False:
             noise_comp, _ = self.mv.compensate(
                 noise,
                 direction=MVDirection.BACKWARD,
@@ -1271,8 +1262,8 @@ class QTGMCGraph(VSObject):
         if self.settings.basic_tr:
             smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.func)
 
-        if self.settings._source_match_enabled:
-            smoothed = self._source_match(smoothed)
+            if self.settings.source_match_iterations:
+                smoothed = self._source_match(smoothed)
 
         if self.settings.lossless_mode is self.settings.LosslessMode.PRESHARPEN:
             smoothed = self._lossless(smoothed)
@@ -1359,7 +1350,7 @@ class QTGMCGraph(VSObject):
 
     @cachedproperty
     def _apply_denoise(self) -> vs.VideoNode:
-        if self.settings._mc_denoise_tr:
+        if self.settings.denoise_mc_denoise and self.settings.denoise_tr:
             denoised = self.mv.compensate(
                 tr=self.settings.denoise_tr,
                 thscd=self.settings.analyze_thscd,

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -78,6 +78,11 @@ class QTGMCArgs:
         limit: float | tuple[float, float] | None
         planes: Planes
 
+    class Blur(TypedDict, total=False):
+        """Arguments accepted by [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur]."""
+
+        prec: int | None
+
     class Mask(TypedDict, total=False):
         """Arguments accepted by [MVTools.mask][vsdenoise.mvtools.mvtools.MVTools.mask]."""
 
@@ -85,11 +90,6 @@ class QTGMCArgs:
         gamma: float | None
         time: float | None
         scval: float | None
-
-    class Blur(TypedDict, total=False):
-        """Arguments accepted by [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur]."""
-
-        prec: int | None
 
 
 class _QTGMCBuilder:
@@ -440,9 +440,9 @@ class _QTGMCBuilder:
         *,
         func: DFTTest | _DenoiseFuncTr = _DFTTEST_DEFAULT,
         tr: int = 1,
-        deint: NoiseDeintMode = NoiseDeintMode.GENERATE,
         mc_denoise: bool = True,
         full_denoise: bool = False,
+        deint: NoiseDeintMode = NoiseDeintMode.GENERATE,
         stabilize: float | Literal[False] = 0.4,
         func_comp_args: QTGMCArgs.Compensate | None = None,
         stabilize_comp_args: QTGMCArgs.Compensate | None = None,
@@ -476,11 +476,11 @@ class _QTGMCBuilder:
             func: Denoising function to use. Defaults to DFTTest(sigma=8).
             tr: Temporal radius of the denoising function and its motion compensation. Larger values remove/separate
                 more noise. Defaults to 1.
-            deint: How to 'deinterlace' noise taken from an interlaced source. Defaults to NoiseDeintMode.GENERATE.
             mc_denoise: Whether to motion-compensate the denoiser being used. Provides more accurate denoising/noise
                 extraction when using a non-motion-compensated temporal denoiser. Defaults to True.
             full_denoise: Whether the denoised output will be directly used in all subsequent processing. If `False`,
                 the denoising is only for noise extraction. Defaults to False.
+            deint: How to 'deinterlace' noise taken from an interlaced source. Defaults to NoiseDeintMode.GENERATE.
             stabilize: Weight used when blending max noise variance with averaged noise. Higher values give more
                 weight to the averaged noise. `False` disables stabilization. Defaults to 0.4.
             func_comp_args: Additional arguments passed to
@@ -492,9 +492,9 @@ class _QTGMCBuilder:
 
         self.denoise_func = func.denoise if isinstance(func, DFTTest) else func
         self.denoise_tr = tr
-        self.denoise_deint = deint
         self.denoise_mc_denoise = mc_denoise
         self.denoise_full_denoise = full_denoise
+        self.denoise_deint = deint
         self.denoise_stabilize = stabilize
         self.denoise_func_comp_args = fallback(func_comp_args, QTGMCArgs.Compensate())
         self.denoise_stabilize_comp_args = fallback(stabilize_comp_args, QTGMCArgs.Compensate())
@@ -576,10 +576,10 @@ class _QTGMCBuilder:
         self,
         *,
         iterations: Literal[0, 1, 2, 3] = 0,
+        similarity: float = 0.5,
         bobber: BobberLike | None = None,
         tr: int = 1,
         enhance: float = 0.5,
-        similarity: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
         mode: SourceMatchMode | None = None,
     ) -> Self:
@@ -610,21 +610,21 @@ class _QTGMCBuilder:
                 `2` or `3` iterations restores almost exact source detail but is sensitive to noise and introduces
                 occasional aliasing (to a lesser extent for `3`). Requires
                 [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `tr` > `0` Defaults to 0.
+            similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
+                Defaults to 0.5.
             bobber: Bobber to use for refined spatial interpolation. Only used for `iterations` > `1`. Defaults to
                 [QTempGaussMC.basic][vsdeinterlace.QTempGaussMC.basic] `bobber`.
             tr: Temporal radius of the refinement motion-compensated binomial blur. Larger values reduce more shimmer
                 but can introduce blurring and ghosting. Only used for `iterations` > `1`. Defaults to 1.
             enhance: Enhances detail found by `iterations` > `1`. Higher values exaggerate detail more. Defaults to 0.5.
-            similarity: Temporal similarity of the error from frame to frame. Lower values make the result sharper.
-                Defaults to 0.5.
             degrain_args: Additional arguments passed to the internal `_binomial_degrain` call. Defaults to None.
         """
 
         self.source_match_iterations = iterations
+        self.source_match_similarity = similarity
         self.source_match_bobber = bobber
         self.source_match_tr = tr
         self.source_match_enhance = enhance
-        self.source_match_similarity = similarity
         self.source_match_degrain_args = fallback(degrain_args, QTGMCArgs.Degrain())
 
         if mode is not None:  # TODO: remove
@@ -1388,7 +1388,7 @@ class QTGMCGraph(VSObject):
 
         angle_in, angle_out = self.settings.motion_blur_shutter_angle
 
-        return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
+        return (angle_out * self._motion_blur_fps_divisor - angle_in) / 3.60
 
     def _interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
         if self.mode is not self.Mode.DESHIMMER:

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -601,7 +601,7 @@ class _QTGMCBuilder:
         similarity: float = 0.5,
         enhance: float = 0.5,
         degrain_args: QTGMCArgs.Degrain | None = None,
-        mode: SourceMatchMode = SourceMatchMode.NONE,
+        mode: SourceMatchMode | None = None,
     ) -> Self:
         """
         Configures parameters for source match processing.

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from enum import auto
 from math import comb
-from typing import Any, Literal, Protocol, Self, TypedDict
+from typing import Any, Literal, Protocol, Self, TypedDict, overload
 
 from jetpytools import CustomIntEnum, CustomValueError, FuncExcept, cachedproperty, fallback, normalize_seq, to_arr
 
@@ -884,6 +884,13 @@ class _QTGMCGraph(VSObject):
         REPAIR = auto()
         DESHIMMER = auto()
 
+    class _FrozenCache(dict[str, Any]):
+        def __contains__(self, key: object) -> bool:
+            return True
+
+        def __missing__(self, key: str) -> Any:
+            raise AttributeError(key)
+
     def __init__(
         self,
         clip: vs.VideoNode,
@@ -893,12 +900,21 @@ class _QTGMCGraph(VSObject):
         func: FuncExcept,
     ) -> None:
         self.clip = clip
-        self.tff = FieldBased.from_param_or_video(tff, self.clip, True, func)
+        self.tff = FieldBased.from_param_or_video(tff, clip, True, func)
         self.mode = mode
         self.settings = settings
+        self.func = func
 
-        if not self.tff.is_inter and self.mode is not self.Mode.DESHIMMER:
+        if not (self.tff.is_inter or mode is self.Mode.DESHIMMER):
             raise UnsupportedFieldBasedError("This mode is incompatible with progressive video!", func)
+
+    def freeze(self) -> Self:
+        cache = self.__dict__.setdefault(cachedproperty.cache_key, {})
+
+        if not isinstance(cache, self._FrozenCache):
+            self.__dict__[cachedproperty.cache_key] = self._FrozenCache(cache)
+
+        return self
 
     def interpolate(self, clip: vs.VideoNode, bobber: Bobber) -> vs.VideoNode:
         if self.mode is not self.Mode.DESHIMMER:
@@ -1102,15 +1118,15 @@ class _QTGMCGraph(VSObject):
     @cachedproperty
     def prefilter(self) -> vs.VideoNode:
         if self.mode is self.Mode.REPAIR:
-            search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self.__class__)
+            search = BlurMatrix.BINOMIAL()(self.draft, mode=ConvMode.VERTICAL, func=self.func)
         else:
             search = self.draft
 
         if self.settings.prefilter_tr:
             smoothed = BlurMatrix.BINOMIAL(self.settings.prefilter_tr, mode=ConvMode.TEMPORAL)(
-                sc_detect(search, self.settings.prefilter_sc_threshold), scenechange=True, func=self.__class__
+                sc_detect(search, self.settings.prefilter_sc_threshold), scenechange=True, func=self.func
             )
-            smoothed = mask_shimmer(smoothed, search, **self.settings.prefilter_mask_shimmer_args, func=self.__class__)
+            smoothed = mask_shimmer(smoothed, search, **self.settings.prefilter_mask_shimmer_args, func=self.func)
         else:
             smoothed = search
 
@@ -1131,17 +1147,16 @@ class _QTGMCGraph(VSObject):
                 lim2=lim2,
                 lim3=lim3,
                 bias=self.settings.prefilter_bias,
-                func=self.__class__,
+                func=self.func,
             )
 
-        return prefilter_to_full_range(blurred, func=self.__class__, **self.settings.prefilter_range_expansion_args)
+        return prefilter_to_full_range(blurred, func=self.func, **self.settings.prefilter_range_expansion_args)
 
     @cachedproperty
     def mv(self) -> MVTools:
+        preset = dict(self.settings.analyze_preset)
         if not self.settings.analyze_vectors:
-            preset = {**self.settings.analyze_preset, "search_clip": self.prefilter}
-        else:
-            preset = self.settings.analyze_preset
+            preset.update(search_clip=self.prefilter)
 
         mv = MVTools(self.draft, vectors=self.settings.analyze_vectors, **preset)
 
@@ -1164,12 +1179,12 @@ class _QTGMCGraph(VSObject):
             bool(self.motion_blur_level),
         )
 
-        self.mv.analyze(tr=tr, blksize=self.settings.analyze_blksize, overlap_div=self.settings.analyze_overlap)
+        mv.analyze(tr=tr, blksize=self.settings.analyze_blksize, overlap_div=self.settings.analyze_overlap)
 
         blksize = self.settings.analyze_blksize
         for _ in range(self.settings.analyze_refine):
             blksize = refine_blksize(blksize)
-            self.mv.recalculate(
+            mv.recalculate(
                 thsad=self.settings.analyze_thsad_recalc, blksize=blksize, overlap_div=self.settings.analyze_overlap
             )
 
@@ -1188,7 +1203,7 @@ class _QTGMCGraph(VSObject):
             denoised = self.settings.denoise_func(self.draft, tr=self.settings.denoise_tr)
 
         if self.mode in (self.Mode.DEINTERLACE, self.Mode.BOB):
-            denoised = reinterlace(denoised, self.tff, self.__class__)
+            denoised = reinterlace(denoised, self.tff, self.func)
 
         return denoised
 
@@ -1209,8 +1224,8 @@ class _QTGMCGraph(VSObject):
                 case self.settings.NoiseDeintMode.GENERATE:
                     noise = noise.std.SeparateFields(self.tff.is_tff)
 
-                    noise_min = Morpho.inpand(noise, sw=2, sh=1, func=self.__class__)
-                    noise_max = Morpho.expand(noise, sw=2, sh=1, func=self.__class__)
+                    noise_min = Morpho.inpand(noise, sw=2, sh=1, func=self.func)
+                    noise_max = Morpho.expand(noise, sw=2, sh=1, func=self.func)
 
                     noise_gen = Grainer.GAUSS(
                         noise,
@@ -1222,9 +1237,9 @@ class _QTGMCGraph(VSObject):
                     noise_gen = norm_expr(
                         [noise_max, noise_min, noise_gen],
                         "y x y - z neutral - range_size / 0.5 + * +",
-                        func=self.__class__,
+                        func=self.func,
                     )
-                    noise = reweave(noise, noise_gen, self.tff.field, self.__class__)
+                    noise = reweave(noise, noise_gen, self.tff.field, self.func)
 
             noise = FieldBased.PROGRESSIVE.apply(noise)
 
@@ -1242,7 +1257,7 @@ class _QTGMCGraph(VSObject):
                 [noise, *noise_comp],
                 "x neutral - abs y neutral - abs > x y ? dup x y + 2 / swap - {weight} * +",
                 weight=self.settings.denoise_stabilize,
-                func=self.__class__,
+                func=self.func,
             )
 
         return noise
@@ -1250,7 +1265,7 @@ class _QTGMCGraph(VSObject):
     @cachedproperty
     def bob_input(self) -> vs.VideoNode:
         if self.mode is self.Mode.REPAIR:
-            return reinterlace(self.denoise, self.tff, self.__class__)
+            return reinterlace(self.denoise, self.tff, self.func)
 
         return self.denoise
 
@@ -1274,7 +1289,7 @@ class _QTGMCGraph(VSObject):
         smoothed = self.binomial_degrain(self.bobbed, self.settings.basic_tr, **self.settings.basic_degrain_args)
 
         if self.settings.basic_tr:
-            smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.__class__)
+            smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.basic_mask_shimmer_args, func=self.func)
 
         if self.settings._source_match_enabled:
             smoothed = self.source_match(smoothed)
@@ -1321,7 +1336,7 @@ class _QTGMCGraph(VSObject):
             smoothed = self.basic
 
         if smoothed is not self.bobbed:
-            smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.final_mask_shimmer_args, func=self.__class__)
+            smoothed = mask_shimmer(smoothed, self.bobbed, **self.settings.final_mask_shimmer_args, func=self.func)
 
         if self.settings.sharpen_limit_mode.is_postsmooth and self.settings._sharpness_limiting_enabled:
             smoothed = self.sharpen_limit(smoothed)
@@ -1372,7 +1387,29 @@ class QTempGaussMC(_QTGMCBuilder):
     Usage Info: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
-    def deinterlace(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
+    @overload
+    def deinterlace(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: Literal[False] = False
+    ) -> vs.VideoNode: ...
+
+    @overload
+    def deinterlace(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, debug: Literal[True]
+    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def deinterlace(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, debug: Literal[True]
+    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def deinterlace(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    def deinterlace(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
         """
         Deinterlace interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor`
         is respected.
@@ -1382,13 +1419,43 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
+            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
-            Deinterlaced clip.
+            The deinterlaced clip, or a tuple of (clip, graph) containing the deinterlaced clip and the internal
+            `_QTGMCGraph` object if debug is True
         """
-        return _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace).motion_blur
 
-    def bob(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
+        run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.DEINTERLACE, self, self.deinterlace)
+
+        if debug:
+            return run.motion_blur, run.freeze()
+
+        return run.motion_blur
+
+    @overload
+    def bob(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: Literal[False] = False
+    ) -> vs.VideoNode: ...
+
+    @overload
+    def bob(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, debug: Literal[True]
+    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def bob(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, debug: Literal[True]
+    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def bob(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    def bob(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
         """
         Bob interlaced input. [QTempGaussMC.motion_blur][vsdeinterlace.QTempGaussMC.motion_blur] `fps_divisor` is
         ignored.
@@ -1398,13 +1465,43 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
+            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
-            Bobbed clip.
+            The bobbed clip, or a tuple of (clip, graph) containing the bobbed clip and the internal `_QTGMCGraph`
+            object if debug is True
         """
-        return _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.BOB, self, self.bob).motion_blur
 
-    def repair(self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None) -> vs.VideoNode:
+        run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.BOB, self, self.bob)
+
+        if debug:
+            return run.motion_blur, run.freeze()
+
+        return run.motion_blur
+
+    @overload
+    def repair(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: Literal[False] = False
+    ) -> vs.VideoNode: ...
+
+    @overload
+    def repair(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, *, debug: Literal[True]
+    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def repair(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None, debug: Literal[True]
+    ) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def repair(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = ...
+    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    def repair(
+        self, clip: vs.VideoNode, tff: FieldBasedLike | bool | None = None, debug: bool = False
+    ) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
         """
         Repair badly deinterlaced input.
 
@@ -1413,13 +1510,30 @@ class QTempGaussMC(_QTGMCBuilder):
         Args:
             clip: Clip to process.
             tff: Field order (top-field-first). If None, inferred from the clip. Defaults to None.
+            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
-            Repaired clip.
+            The repaired clip, or a tuple of (clip, graph) containing the repaired clip and the internal `_QTGMCGraph`
+            object if debug is True
         """
-        return _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.REPAIR, self, self.repair).motion_blur
 
-    def deshimmer(self, clip: vs.VideoNode) -> vs.VideoNode:
+        run = _QTGMCGraph(clip, tff, _QTGMCGraph.Mode.REPAIR, self, self.repair)
+
+        if debug:
+            return run.motion_blur, run.freeze()
+
+        return run.motion_blur
+
+    @overload
+    def deshimmer(self, clip: vs.VideoNode, debug: Literal[False] = False) -> vs.VideoNode: ...
+
+    @overload
+    def deshimmer(self, clip: vs.VideoNode, debug: Literal[True]) -> tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    @overload
+    def deshimmer(self, clip: vs.VideoNode, debug: bool = ...) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]: ...
+
+    def deshimmer(self, clip: vs.VideoNode, debug: bool = False) -> vs.VideoNode | tuple[vs.VideoNode, _QTGMCGraph]:
         """
         Deshimmer progressive input.
 
@@ -1427,11 +1541,19 @@ class QTempGaussMC(_QTGMCBuilder):
 
         Args:
             clip: Clip to process.
+            debug: Whether to return the internal `_QTGMCGraph` object. Defaults to False.
 
         Returns:
-            Deshimmered clip.
+            The deshimmered clip, or a tuple of (clip, graph) containing the deshimmered clip and the internal
+            `_QTGMCGraph` object if debug is True
         """
-        return _QTGMCGraph(clip, FieldBased.PROGRESSIVE, _QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer).motion_blur
+
+        run = _QTGMCGraph(clip, FieldBased.PROGRESSIVE, _QTGMCGraph.Mode.DESHIMMER, self, self.deshimmer)
+
+        if debug:
+            return run.motion_blur, run.freeze()
+
+        return run.motion_blur
 
 
 def mask_shimmer(

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -910,13 +910,6 @@ class _QTGMCBuilder:
         return sqrt(self.basic_tr / 2 + self.final_tr * (self.final_tr + 1) / 3)
 
     @property
-    def _sharpening_enabled(self) -> bool:
-        return bool(
-            ((self.sharpen_strength and self._sharpen_sigma) or self.sharpen_thin)
-            and (self.back_blend_mode is self.BackBlendMode.NONE or self._back_blend_sigma)
-        )
-
-    @property
     def _back_blend_sigma(self) -> float:
         passes = 1 + bool(
             self.back_blend_mode is self.BackBlendMode.BOTH
@@ -925,6 +918,13 @@ class _QTGMCBuilder:
         )
 
         return self._sharpen_sigma * (self.back_blend_scale / sqrt(passes))
+
+    @property
+    def _sharpening_enabled(self) -> bool:
+        return bool(
+            ((self.sharpen_strength and self._sharpen_sigma) or self.sharpen_thin)
+            and (self.back_blend_mode is self.BackBlendMode.NONE or self._back_blend_sigma)
+        )
 
     @property
     def _sharpness_limiting_enabled(self) -> bool:
@@ -958,6 +958,8 @@ class QTGMCGraph(VSObject):
         deinterlaced, graph = qtgmc.deinterlace(clip, return_graph=True)
         prefilter = graph.prefilter
         ```
+
+    Additional Usage Info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     class Mode(CustomIntEnum):
@@ -1578,16 +1580,17 @@ class QTempGaussMC(_QTGMCBuilder):
         ```python
         deinterlaced = QTempGaussMC().deinterlace(clip)
         ```
-        - Using `EEDI3` for interpolation:
+        - Using [EEDI3][vsaa.EEDI3] for interpolation:
         ```python
         deinterlaced = QTempGaussMC().basic(bobber=EEDI3()).deinterlace(clip)
         ```
-        - Enabling lossless and increasing final `tr`:
+        - Enabling [QTempGaussMC.lossless][vsdeinterlace.QTempGaussMC.lossless] and increasing
+            [QTempGaussMC.final][vsdeinterlace.QTempGaussMC.final] `tr`:
         ```python
         deinterlaced = QTempGaussMC().lossless(QTempGaussMC.LosslessMode.PRESHARPEN).final(tr=2).deinterlace(clip)
         ```
 
-    Additional Usage Info: [JET guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
+    Additional Usage Info: [JET Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)
     """
 
     @overload

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -880,7 +880,7 @@ class _QTGMCBuilder:
     def motion_blur(
         self,
         *,
-        shutter_angle: tuple[float, float] = (180, 180),
+        shutter_angle: tuple[float, float] | Literal[False] = False,
         fps_divisor: int = 1,
         blur_args: QTGMCArgs.Blur | None = None,
         mask_args: QTGMCArgs.Mask | None = None,
@@ -902,7 +902,7 @@ class _QTGMCBuilder:
 
         Args:
             shutter_angle: Tuple containing the source and output shutter angles. Motion blur is applied if they do not
-                match. Defaults to (180, 180).
+                match. `False` disables motion blur. Defaults to False.
             fps_divisor: Factor by which to smoothly reduce frame rate. Defaults to 1.
             blur_args: Additional arguments passed to [MVTools.flow_blur][vsdenoise.mvtools.mvtools.MVTools.flow_blur].
                 Defaults to None.
@@ -1206,6 +1206,9 @@ class QTGMCGraph(VSObject):
 
     @cachedproperty
     def _motion_blur_level(self) -> float:
+        if self.settings.motion_blur_shutter_angle is False:
+            return 0
+
         angle_in, angle_out = self.settings.motion_blur_shutter_angle
 
         return (angle_out * self._motion_blur_fps_divisor - angle_in) * 100 / 360
@@ -1306,9 +1309,9 @@ class QTGMCGraph(VSObject):
             bool(self._motion_blur_level),
         )
 
-        mv.analyze(tr=tr, blksize=self.settings.analyze_blksize, overlap_div=self.settings.analyze_overlap)
-
         blksize = self.settings.analyze_blksize
+        mv.analyze(tr=tr, blksize=blksize, overlap_div=self.settings.analyze_overlap)
+
         for _ in range(self.settings.analyze_refine):
             blksize = refine_blksize(blksize)
             mv.recalculate(

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -946,17 +946,18 @@ class QTGMCGraph(VSObject):
     Returned graphs are frozen after evaluation so that access is limited to stages used to construct the output.
 
     Usage examples:
-        - Reusing the [MVTools][vsdenoise.mvtools.mvtools.MVTools] object:
-        ```python
-        qtgmc = vsdeinterlace.QTempGaussMC()
-        deinterlaced, graph = qtgmc.deinterlace(clip, return_graph=True)
-        mv = graph.mv
-        ```
         - Inspecting the output of [QTempGaussMC.prefilter][vsdeinterlace.QTempGaussMC.prefilter]:
         ```python
         qtgmc = vsdeinterlace.QTempGaussMC()
         deinterlaced, graph = qtgmc.deinterlace(clip, return_graph=True)
         prefilter = graph.prefilter
+        ```
+        - Reusing the internal [MVTools][vsdenoise.mvtools.mvtools.MVTools] object's
+            [MotionVectors][vsdenoise.mvtools.motion.MotionVectors]:
+        ```python
+        qtgmc = vsdeinterlace.QTempGaussMC()
+        deinterlaced, graph = qtgmc.deinterlace(clip, return_graph=True)
+        vectors = graph.mv.vectors
         ```
 
     Additional usage info: [JET Encoding Guide](https://jaded-encoding-thaumaturgy.github.io/JET-guide/master/filtering/situational/qtgmc/)

--- a/vsdeinterlace/qtgmc.py
+++ b/vsdeinterlace/qtgmc.py
@@ -774,9 +774,6 @@ class _QTGMCBuilder:
 
     @property
     def back_blend_scale(self) -> float:
-        if not self._back_blend_scale:
-            return 0
-
         passes = 1 + bool(
             self.back_blend_mode is self.BackBlendMode.BOTH
             and self.sharpen_limit_mode.is_presmooth


### PR DESCRIPTION
Changes:
 - Docs have been completely rewritten
 - mask_shimmer is now a public function
 - ruff warnings fixed
 - Settings builder has been split into a separate class
 - Processing has been split into a separate class
 - Chained method calls have been replaced with a proper graph builder using lazy processing
 - Redundant enums deprecated
 - General code refactors for correctness/readability
 - Can now pass your own motion vectors
 - thsad2 added
 - Sharpening has been reworked and is now scaled sanely
 - misc fixes