### PR TITLE
vsscale: allow skipping TRT FP16 conversion

### DIFF
--- a/tests/vsscale/test_backend_trt.py
+++ b/tests/vsscale/test_backend_trt.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from vsscale.mlrt.backend.trt import TRT
+
+
+def test_trt_skips_fp16_conversion_for_preconverted_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    model = tmp_path / "model_fp16.onnx"
+    model.write_bytes(b"model")
+    engine = tmp_path / "model.engine"
+    converted = False
+
+    def convert_fp16(self: TRT, network_path: Path) -> Path:
+        nonlocal converted
+        converted = True
+        return network_path
+
+    monkeypatch.setattr(TRT, "_convert_onnx_fp16", convert_fp16)
+    monkeypatch.setattr(TRT, "get_identity", lambda self, *args: 1)
+    monkeypatch.setattr(
+        "vsscale.mlrt.backend.trt.get_artifact_path",
+        lambda *args, **kwargs: engine,
+    )
+    monkeypatch.setattr(TRT, "build", lambda self, **kwargs: engine.write_bytes(b"engine" * 512))
+
+    backend = TRT(fp16=True, skip_fp16_conversion=True)
+    assert backend.build_engine(model, channels=3, tilesize=(64, 64)) == engine
+    assert converted is False

--- a/vsscale/mlrt/backend/trt.py
+++ b/vsscale/mlrt/backend/trt.py
@@ -58,6 +58,8 @@ class TRT(Backend):
     # Model Precision & Data Types
     fp16: bool | None = None
     """Convert the ONNX model to FP16 before building. Default to True."""
+    skip_fp16_conversion: bool = False
+    """Skip ONNX FP16 conversion when the model is already in FP16 format."""
     fp16_blacklist_ops: Collection[str] | None = None
     """ONNX node or op names to keep in FP32 during FP16 conversion."""
     bf16: bool | None = None
@@ -236,7 +238,7 @@ class TRT(Backend):
         Returns:
             Path to the serialized engine file.
         """
-        if self.fp16:
+        if self.fp16 and not self.skip_fp16_conversion:
             network_path = self._convert_onnx_fp16(network_path)
         elif self.bf16:
             network_path = self._convert_onnx_bf16(network_path)


### PR DESCRIPTION
## Summary

- Add `TRT(skip_fp16_conversion=True)` for pre-converted FP16 ONNX models.
- Keep FP16 clip I/O enabled while skipping the redundant ONNX conversion.
- Add a regression test covering the new option.

## Motivation

Using a pre-converted FP16 ONNX model with `fp16=True` currently attempts to convert it again and raises `ValueError` from `onnxconverter-common`. Setting `fp16=False` avoids conversion but makes the backend convert clips to FP32, which causes a TensorRT `bits per sample mismatch` for FP16 I/O models.

This option separates the ONNX conversion step from the FP16 I/O behavior.

## Testing

- `env -u VSSCALE_GLOBAL -u VSSCALE_ONNX_GLOBAL uv run pytest -q tests/vsscale/test_backend_trt.py` (2 passed)
- `env -u VSSCALE_GLOBAL -u VSSCALE_ONNX_GLOBAL pytest -q tests/vsscale/test_backend_trt.py tests/vsscale/test_settings.py` (11 passed)
- `uv run ruff check vsscale/mlrt/backend/trt.py tests/vsscale/test_backend_trt.py`
