### PR TITLE
enable satd analyze and tune lambda for mvtools hq presets

### DIFF
--- a/vsdenoise/mvtools/presets.py
+++ b/vsdenoise/mvtools/presets.py
@@ -217,7 +217,7 @@ class MVToolsPreset(VSObjectABC, Mapping[str, Any]):
     def HQ_COHERENCE(cls) -> MVToolsPreset:  # noqa: N802
         return cls(
             search_clip=prefilter_to_full_range,
-            analyze_args=AnalyzeArgs(blksize=16, overlap_div=2),
+            analyze_args=AnalyzeArgs(blksize=16, overlap_div=2, satd=True),
             recalculate_args=RecalculateArgs(blksize=8, overlap_div=2, satd=True),
         )
 
@@ -226,6 +226,6 @@ class MVToolsPreset(VSObjectABC, Mapping[str, Any]):
     def HQ_SAD(cls) -> MVToolsPreset:  # noqa: N802
         return cls(
             search_clip=prefilter_to_full_range,
-            analyze_args=AnalyzeArgs(blksize=16, overlap_div=2, mvlambda=0),
-            recalculate_args=RecalculateArgs(blksize=8, overlap_div=2, satd=True, mvlambda=0),
+            analyze_args=AnalyzeArgs(blksize=16, overlap_div=2, satd=True, mvlambda=100),
+            recalculate_args=RecalculateArgs(blksize=8, overlap_div=2, satd=True, mvlambda=100),
         )


### PR DESCRIPTION
This follows [QTGMC](https://github.com/emotion3459/havsfunc/blob/qtgmc_old/havsfunc/havsfunc.py#L631)'s lambda tuning where lambda is set to 100 (one tenth of truemotion=True's old default) instead of 0.
Mvutensils's tuned defaults generally followed QTGMC's tweaks (as they fared better than the plugin defaults), but as the truemotion toggle was removed this one was omitted.
Zeroing out lambda disables several ME heuristics and results in noise being picked up as motion.
On unstable sources, typically you would need massive block sizes + many refinements for acceptable noise reduction.
Even just a very small lambda (like a value of 100) solves this problem. Enabling users to use smaller block sizes with less refinements (no more recalc chains = more performance) and allows lower thsads to be used (improving quality).
Similarly with satd, it was disabled from the analyze args because of the above issue, causing too much noise to be picked up as motion, preventing denoising. The lambda tune fixes this and allows satd to be used for analyze as well, which improves detail retention.